### PR TITLE
Fix the class that CifCodDepositParser inherits from

### DIFF
--- a/aiida_codtools/parsers/cif_cod_deposit.py
+++ b/aiida_codtools/parsers/cif_cod_deposit.py
@@ -20,7 +20,7 @@ cod_deposition_states = CodDepositionState((
 ))
 
 
-class CifCodDepositParser(CiffilterParser):
+class CifCodDepositParser(CifBaseParser):
     """
     Specific parser for the output of cif_cod_deposit script.
     """


### PR DESCRIPTION
This was missed in the recent name changes