### PR TITLE
CifCleanWorkChain: make the parsing engine an optional input

### DIFF
--- a/aiida_codtools/workflows/cif_clean.py
+++ b/aiida_codtools/workflows/cif_clean.py
@@ -15,18 +15,23 @@ CifFilterCalculation = CalculationFactory('codtools.cif_filter')
 CifSelectCalculation = CalculationFactory('codtools.cif_select')
 
 
+class CifParseError(BaseException):
+    pass
+
+
 class CifCleanWorkChain(WorkChain):
     """
     WorkChain to clean a CifData node using the cif_filter and cif_select scripts of cod-tools
     It will first run cif_filter to correct syntax errors, followed by cif_select which will remove
     various tags and canonicalize the remaining tags. If a group is passed for the group_structure
-    input, ASE will be used to parse the final cleaned CifData to construct a StructureData object
-    which will then be passed to the SeeKpath library to analyze it and return the primitive structure
+    input, the atomic structure library defined by the 'engine' input will be used to parse the final
+    cleaned CifData to construct a StructureData object, which will then be passed to the SeeKpath
+    library to analyze it and return the primitive structure
     """
 
     ERROR_CIF_FILTER_FAILED = 1
     ERROR_CIF_SELECT_FAILED = 2
-    ERROR_SEEKPATH_FAILED = 3
+    ERROR_CIF_PARSE_STRUCTURE_FAILED = 3
 
     @classmethod
     def define(cls, spec):
@@ -41,6 +46,8 @@ class CifCleanWorkChain(WorkChain):
             help='options for the calculations')
         spec.input('tags', valid_type=Str, default=Str('_publ_author_name,_citation_journal_abbrev'),
             help='comma separated tag names that are to be removed by the cif_select step')
+        spec.input('parse_engine', valid_type=Str, default=Str('pymatgen'),
+            help='the atomic structure engine to parse the cif and create the structure')
         spec.input('symprec', valid_type=Float, default=Float(5E-3),
             help='the symmetry precision used by SeeK-path for crystal symmetry refinement')
         spec.input('group_cif', valid_type=Group, required=False, non_db=True,
@@ -52,8 +59,8 @@ class CifCleanWorkChain(WorkChain):
             cls.inspect_filter_calculation,
             cls.run_select_calculation,
             cls.inspect_select_calculation,
-            if_(cls.should_create_structure)(
-                cls.create_reduced_structure,
+            if_(cls.should_parse_cif_structure)(
+                cls.parse_cif_structure,
             ),
             cls.results,
         )
@@ -130,53 +137,67 @@ class CifCleanWorkChain(WorkChain):
             self.report('aborting: the CifSelectCalculation did not return the required cif output')
             return self.ERROR_CIF_SELECT_FAILED
 
-    def should_create_structure(self):
+    def should_parse_cif_structure(self):
         """
         Return whether the primitive structure should be created from the final cleaned CifData
         Will be true if the 'group_structure' input is specified
         """
         return 'group_structure' in self.inputs
 
-    def create_reduced_structure(self):
+    def parse_cif_structure(self):
         """
         Create a StructureData from the CifData output node returned by the CifSelectCalculation and
-        find the primitive cell structure through the SeeK-path library
+        find the primitive cell structure through the SeeKpath library
         """
-        result = cif_reduce_seekpath(self.ctx.cif, self.inputs.symprec)
+        try:
+            result = primitive_structure_from_cif(self.ctx.cif, self.inputs.parse_engine, self.inputs.symprec)
+        except CifParseError as exception:
+            parser_engine = self.inputs.parse_engine.value
+            self.report('parse engine {} failed to parse the cif'.format(parser_engine))
+            return
 
         try:
             self.ctx.structure = result['primitive_structure']
-        except AttributeError:
-            self.report('aborting: SeeKpath did not return a primitive structure')
-            return self.ERROR_SEEKPATH_FAILED
+        except KeyError:
+            self.report('SeeKpath failed to return a primitive structure')
+            return
 
     def results(self):
         """
         The filter and select calculations were successful, so we return the desired output nodes
         """
-        returned_nodes = []
-
         if 'group_cif' in self.inputs:
             cif = self.ctx.cif
             self.inputs.group_cif.add_nodes([cif])
             self.out('cif', cif)
-            returned_nodes.append('CifData<{}>'.format(cif.pk))
 
         if 'group_structure' in self.inputs:
-            structure = self.ctx.structure
-            self.inputs.group_structure.add_nodes([structure])
-            self.out('structure', structure)
-            returned_nodes.append('StructureData<{}>'.format(structure.pk))
+            try:
+                structure = self.ctx.structure
+            except AttributeError:
+                return self.ERROR_CIF_PARSE_STRUCTURE_FAILED
+            else:
+                self.inputs.group_structure.add_nodes([structure])
+                self.out('structure', structure)
 
-
-        self.report('workchain finished successfully, returned nodes {}'.format(', '.join(returned_nodes)))
+        self.report('workchain finished successfully')
 
 
 @workfunction
-def cif_reduce_seekpath(cif, symprec):
+def primitive_structure_from_cif(cif, parse_engine, symprec):
     """
     This workfunction will take a CifData node, create a StructureData object from it
-    and pass it through SeeKpath to get the primitive cell
+    using the 'parse_engine' and pass it through SeeKpath to get the primitive cell
+
+    :param cif: the CifData node
+    :param parse_engine: the parsing engine, supported libraries 'ase' and 'pymatgen'
+    :param symprec: a Float node with symmetry precision for determining primitive cell in SeeKpath
     """
-    structure = StructureData(ase=cif.get_ase())
+    import traceback
+
+    try:
+        structure = cif._get_aiida_structure(converter=parse_engine.value, store=False)
+    except BaseException as exception:
+        raise CifParseError(traceback.format_exc())
+
     return get_kpoints_path(structure, symprec=symprec) 


### PR DESCRIPTION
Fixes #14 

The parsing engine that was used to parse the cleaned cif file for
the structure was hardcoded to be ASE, however, pymatgen is also
natively supported by the CifData class and some users may prefer
that one. Additionally, during testing, it was found that parsing
the cif with ASE could raise exceptions such as SpacegroupNotFoundError
or an AttributeError raised in method in 'tags2atoms' module.
As a solution we catch these exception and raise CifParseError.
This will cause the workchain to return the ERROR_CIF_PARSE_STRUCTURE_FAILED
error code indicating that parsing the structure failed. Note
that this will only happen if the user asked for the structure to be
parsed as that is optional