### PR TITLE
Improve option flags and output verbosity of cif clean script

### DIFF
--- a/aiida_codtools/cli/workflows/cif_clean.py
+++ b/aiida_codtools/cli/workflows/cif_clean.py
@@ -6,24 +6,24 @@ from aiida.utils.cli import options
 
 @command()
 @options.code(
-    '--cif-filter', callback_kwargs={'entry_point': 'codtools.cif_filter'},
+    '-F', '--cif-filter', callback_kwargs={'entry_point': 'codtools.cif_filter'},
     help='Code that references the codtools cif_filter script'
 )
 @options.code(
-    '--cif-select', callback_kwargs={'entry_point': 'codtools.cif_select'},
+    '-S', '--cif-select', callback_kwargs={'entry_point': 'codtools.cif_select'},
     help='Code that references the codtools cif_select script'
 )
 @options.group(
-    '--group-cif-raw', required=False, help='Group with the raw CifData nodes to be cleaned'
+    '-r', '--group-cif-raw', required=False, help='Group with the raw CifData nodes to be cleaned'
 )
 @options.group(
-    '--group-cif-clean', required=False, help='Group to which to add the cleaned CifData nodes'
+    '-c', '--group-cif-clean', required=False, help='Group to which to add the cleaned CifData nodes'
 )
 @options.group(
-    '--group-structure', required=False, help='Group to which to add the final StructureData nodes'
+    '-s', '--group-structure', required=False, help='Group to which to add the final StructureData nodes'
 )
 @options.group(
-    '--group-workchain', required=False, help='Group to which to add the WorkChain nodes'
+    '-w', '--group-workchain', required=False, help='Group to which to add the WorkChain nodes'
 )
 @click.option(
     '-n', '--node', type=click.INT, default=None, required=False,
@@ -42,10 +42,8 @@ from aiida.utils.cli import options
     help='Select the parse engine for parsing the structure from the cleaned cif if requested'
 )
 @options.daemon()
-@options.max_num_machines()
-@options.max_wallclock_seconds()
 def launch(cif_filter, cif_select, group_cif_raw, group_cif_clean, group_structure, group_workchain, node,
-    max_entries, skip_check, parse_engine, max_num_machines, max_wallclock_seconds, daemon):
+    max_entries, skip_check, parse_engine, daemon):
     """
     Run the CifCleanWorkChain on the entries in a group with raw imported CifData nodes. It will use
     the cif_filter and cif_select scripts of cod-tools to clean the input cif file. Additionally, if the
@@ -53,6 +51,7 @@ def launch(cif_filter, cif_select, group_cif_raw, group_cif_clean, group_structu
     to parse the cleaned CifData to obtain the structure and then use SeeKpath to find the
     primitive structure, which, if successful, will be added to the group-structure group
     """
+    import inspect
     from datetime import datetime
     from aiida.common.exceptions import NotExistent
     from aiida.orm import load_node
@@ -62,7 +61,7 @@ def launch(cif_filter, cif_select, group_cif_raw, group_cif_clean, group_structu
     from aiida.orm.querybuilder import QueryBuilder
     from aiida.orm.utils import CalculationFactory, DataFactory, WorkflowFactory
     from aiida.work.launch import run_get_node, submit
-    from aiida_quantumespresso.utils.resources import get_default_options
+    from aiida_codtools.common.resources import get_default_options
 
     CifData = DataFactory('cif')
     CifFilterCalculation = CalculationFactory('codtools.cif_filter')
@@ -94,14 +93,25 @@ def launch(cif_filter, cif_select, group_cif_raw, group_cif_clean, group_structu
     else:
         raise click.BadParameter('you have to specify either --group-cif-raw or --node')
 
+
+    # Collect the dictionary of not None parameters passed to the launch script and print to screen
+    local_vars = locals()
+    launch_paramaters = {}
+    for arg in inspect.getargspec(launch.callback).args:
+        if arg in local_vars and local_vars[arg]:
+            launch_paramaters[arg] = local_vars[arg]
+
+    click.echo('=' * 80)
     click.echo('Starting cif clean on {}'.format(datetime.utcnow().isoformat()))
+    click.echo('Launch parameters: {}'.format(launch_paramaters))
+    click.echo('-' * 80)
 
     counter = 0
 
     for cif in nodes:
 
         if not skip_check and cif.pk in completed_cif_nodes:
-            click.echo('CifData<{}> skipped: already submitted'.format(cif.pk))
+            click.echo('{} | CifData<{}> skipped: already submitted'.format(datetime.utcnow().isoformat(), cif.pk))
             continue
 
         inputs = {
@@ -109,7 +119,7 @@ def launch(cif_filter, cif_select, group_cif_raw, group_cif_clean, group_structu
             'cif_filter': cif_filter,
             'cif_select': cif_select,
             'parse_engine': Str(parse_engine),
-            'options': ParameterData(dict=get_default_options(max_num_machines, max_wallclock_seconds))
+            'options': ParameterData(dict=get_default_options())
         }
 
         if group_cif_clean is not None:
@@ -120,9 +130,11 @@ def launch(cif_filter, cif_select, group_cif_raw, group_cif_clean, group_structu
 
         if daemon:
             workchain = submit(CifCleanWorkChain, **inputs)
-            click.echo('CifData<{}> submitting: {}<{}>'.format(cif.pk, CifCleanWorkChain.__name__, workchain.pk))
+            click.echo('{} | CifData<{}> submitting: {}<{}>'.format(
+                datetime.utcnow().isoformat(), cif.pk, CifCleanWorkChain.__name__, workchain.pk))
         else:
-            click.echo('CifData<{}> running: {}'.format(cif.pk, CifCleanWorkChain.__name__))
+            click.echo('{} | CifData<{}> running: {}'.format(
+                datetime.utcnow().isoformat(), cif.pk, CifCleanWorkChain.__name__))
             result, workchain = run_get_node(CifCleanWorkChain, **inputs)
 
         if group_workchain is not None:
@@ -131,7 +143,10 @@ def launch(cif_filter, cif_select, group_cif_raw, group_cif_clean, group_structu
         counter += 1
 
         if max_entries is not None and counter >= max_entries:
-            click.echo('Maximum number of entries {} completed'.format(max_entries))
             break
 
+
+    click.echo('-' * 80)
+    click.echo('Submitted {} new workchains'.format(counter))
     click.echo('Stopping cif clean on {}'.format(datetime.utcnow().isoformat()))
+    click.echo('=' * 80)

--- a/aiida_codtools/common/resources.py
+++ b/aiida_codtools/common/resources.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+
+def get_default_options(num_machines=1, max_wallclock_seconds=1800):
+    """
+    Return an instance of the options dictionary with the minimally required parameters
+    for a JobCalculation and set to default values unless overriden
+
+    :param num_machines: set the number of nodes, default=1
+    :param max_wallclock_seconds: set the maximum number of wallclock seconds, default=1800
+    """
+    return {
+        'resources': {
+            'num_machines': int(num_machines)
+        },
+        'max_wallclock_seconds': int(max_wallclock_seconds),
+    }


### PR DESCRIPTION
Also removed the import of get_default_options from the
aiida-quantumespresso package and copied it here, so as to make
it independent of that plugin