### PR TITLE
 Update the CifCleanWorkChain to use the exit code API

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -45,7 +45,7 @@
         ]
     },
     "install_requires": [
-        "aiida-core>=0.10.0rc1"
+        "aiida-core>=1.0.0a1"
     ],
     "license": "MIT License",
     "name": "aiida_codtools",


### PR DESCRIPTION
Fixes #33 

Changes in aiida-core now allow a WorkChain to define its known error
modes through its ProcessSpec by means of exit codes. These exit codes
define an integer exit status and a more detailed description and can
be referenced during the WorkChain through a human readable label.
Returning an exit code from the WorkChain or workfunction will signal
the workflow engine to stop the execution.