### PR TITLE
Use `--dont-treat-dots-as-underscores` in CifCleanWorkChain

### DIFF
--- a/aiida_codtools/workflows/cif_clean.py
+++ b/aiida_codtools/workflows/cif_clean.py
@@ -124,6 +124,7 @@ class CifCleanWorkChain(WorkChain):
             'canonicalize-tag-names': True,
             'invert': True,
             'tags': self.inputs.tags.value,
+            'dont-treat-dots-as-underscores': True,
         }
 
         inputs = AttributeDict({


### PR DESCRIPTION
Fixes #39 

By default `cif_select` in `cod-tools` will treat dots as underscores
and will replace the former with the latter. However, in v0.2.1 it
will not check if this results in duplicate keys, which if the case
will except the `CifData` constructor, causing the workchain to fail.
As a workaround for version of `cod-tools` with this bug, we can pass
the option `--dont-treat-dots-as-underscores` which will stop it from
converting dots to underscores.