### PR TITLE
`CifBaseParser`: do not except if stdout cannot be parsed into `CifData`

### DIFF
--- a/aiida_codtools/parsers/cif_base.py
+++ b/aiida_codtools/parsers/cif_base.py
@@ -62,13 +62,15 @@ class CifBaseParser(Parser):
         :param filelike: filelike object of stdout
         :returns: an exit code in case of an error, None otherwise
         """
+        from CifFile import StarError
+
         if not filelike.read().strip():
             return self.exit_codes.ERROR_EMPTY_OUTPUT_FILE
 
         try:
             filelike.seek(0)
             cif = CifData(file=filelike)
-        except Exception:  # pylint: disable=broad-except
+        except StarError:
             self.logger.exception('Failed to parse a `CifData` from the stdout file\n%s', traceback.format_exc())
             return self.exit_codes.ERROR_PARSING_CIF_DATA
         else:

--- a/tests/parsers/fixtures/cif_filter/invalid_cif/aiida.out
+++ b/tests/parsers/fixtures/cif_filter/invalid_cif/aiida.out
@@ -1,0 +1,1 @@
+Output data that is not a valid CIF format

--- a/tests/parsers/test_cif_filter.py
+++ b/tests/parsers/test_cif_filter.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 """Tests for the `CifBaseParser`."""
+from __future__ import absolute_import
+from aiida_codtools.calculations.cif_filter import CifFilterCalculation
 
 
 def test_cif_filter(fixture_database, fixture_computer_localhost, generate_calc_job_node, generate_parser):
@@ -14,3 +16,18 @@ def test_cif_filter(fixture_database, fixture_computer_localhost, generate_calc_
 
     assert node.exit_status in (None, 0)
     assert 'cif' in results
+
+
+def test_cif_filter_invalid_cif(fixture_database, fixture_computer_localhost, generate_calc_job_node, generate_parser):
+    """Test that invalid CIF written to stdout will result in `ERROR_PARSING_CIF_DATA`."""
+    entry_point_calc_job = 'codtools.cif_filter'
+    entry_point_parser = 'codtools.cif_base'
+
+    node = generate_calc_job_node(entry_point_calc_job, fixture_computer_localhost, 'invalid_cif')
+    parser = generate_parser(entry_point_parser)
+    _, calcfunction = parser.parse_from_node(node, store_provenance=False)
+
+    assert calcfunction.is_finished
+    assert not calcfunction.is_finished_ok
+    assert calcfunction.exit_status == CifFilterCalculation.exit_codes.ERROR_PARSING_CIF_DATA.status  # pylint: disable=no-member
+    assert calcfunction.exit_message == CifFilterCalculation.exit_codes.ERROR_PARSING_CIF_DATA.message  # pylint: disable=no-member


### PR DESCRIPTION
Fixes #45 

Sometimes the stdout procuded by scripts like `cif_filter` and
`cif_select` will not always contain a correct CIF, with the consequence
that the attempted construction of a `CifData` from it in the parser
will raise an exception. An example is where if the script is run with
MPI and an error is encountered there, the process terminates after
writing the error message to stdout. The exception thrown by the parsing
into a `CifData` should be caught and transformed to appropriate exit code.