### PR TITLE
Update `CifCleanWorkChain` to use new `aiida-core` features

### DIFF
--- a/aiida_codtools/cli/workflows/cif_clean.py
+++ b/aiida_codtools/cli/workflows/cif_clean.py
@@ -130,7 +130,6 @@ def launch_cif_clean(cif_filter, cif_select, group_cif_raw, group_cif_clean, gro
         'use-c-parser': True,
     })
 
-    node_options = get_input_node(orm.Dict, get_default_options())
     node_parse_engine = get_input_node(orm.Str, parse_engine)
     node_site_tolerance = get_input_node(orm.Float, 5E-4)
     node_symprec = get_input_node(orm.Float, 5E-3)
@@ -139,11 +138,20 @@ def launch_cif_clean(cif_filter, cif_select, group_cif_raw, group_cif_clean, gro
 
         inputs = {
             'cif': cif,
-            'cif_filter': cif_filter,
-            'cif_select': cif_select,
-            'cif_filter_parameters': node_cif_filter_parameters,
-            'cif_select_parameters': node_cif_select_parameters,
-            'options': node_options,
+            'cif_filter': {
+                'code': cif_filter,
+                'parameters': node_cif_filter_parameters,
+                'metadata': {
+                    'options': get_default_options()
+                }
+            },
+            'cif_select': {
+                'code': cif_select,
+                'parameters': node_cif_select_parameters,
+                'metadata': {
+                    'options': get_default_options()
+                }
+            },
             'parse_engine': node_parse_engine,
             'site_tolerance': node_site_tolerance,
             'symprec': node_symprec,

--- a/aiida_codtools/workflows/cif_clean.py
+++ b/aiida_codtools/workflows/cif_clean.py
@@ -78,6 +78,7 @@ class CifCleanWorkChain(WorkChain):
     def run_filter_calculation(self):
         """Run the CifFilterCalculation on the CifData input node."""
         inputs = self.exposed_inputs(CifFilterCalculation, namespace='cif_filter')
+        inputs.metadata.call_link_label = 'cif_filter'
         inputs.cif = self.inputs.cif
 
         calculation = self.submit(CifFilterCalculation, **inputs)
@@ -97,6 +98,7 @@ class CifCleanWorkChain(WorkChain):
     def run_select_calculation(self):
         """Run the CifSelectCalculation on the CifData output node of the CifFilterCalculation."""
         inputs = self.exposed_inputs(CifSelectCalculation, namespace='cif_select')
+        inputs.metadata.call_link_label = 'cif_select'
         inputs.cif = self.ctx.cif
 
         calculation = self.submit(CifSelectCalculation, **inputs)
@@ -141,6 +143,9 @@ class CifCleanWorkChain(WorkChain):
             'parse_engine': self.inputs.parse_engine,
             'site_tolerance': self.inputs.site_tolerance,
             'symprec': self.inputs.symprec,
+            'metadata': {
+                'call_link_label': 'primitive_structure_from_cif'
+            }
         }
 
         try:

--- a/aiida_codtools/workflows/functions/primitive_structure_from_cif.py
+++ b/aiida_codtools/workflows/functions/primitive_structure_from_cif.py
@@ -60,6 +60,6 @@ def primitive_structure_from_cif(cif, parse_engine, symprec, site_tolerance):
         except KeyError:
             pass
 
-    structure.set_extras(extras)
+    structure.set_extra_many(extras)
 
     return structure

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def generate_calc_job_node():
         node.set_option('max_wallclock_seconds', 1800)
 
         if attributes:
-            node.set_attributes(attributes)
+            node.set_attribute_many(attributes)
 
         node.store()
 


### PR DESCRIPTION
The inputs of `CalcJobs` can now be exposed and call link labels can be set