### PR TITLE
Use binary file mode when creating `CifData` from a filelike

### DIFF
--- a/aiida_codtools/parsers/cif_base.py
+++ b/aiida_codtools/parsers/cif_base.py
@@ -46,7 +46,7 @@ class CifBaseParser(Parser):
             return exit_code
 
         try:
-            with output_folder.open(filename_stdout, 'r') as handle:
+            with output_folder.open(filename_stdout, 'rb') as handle:
                 handle.seek(0)
                 exit_code = self.parse_stdout(handle)
         except (OSError, IOError):

--- a/aiida_codtools/parsers/cif_cell_contents.py
+++ b/aiida_codtools/parsers/cif_cell_contents.py
@@ -29,6 +29,9 @@ class CifCellContentsParser(CifBaseParser):
         if not content:
             return self.exit_codes.ERROR_EMPTY_OUTPUT_FILE
 
+        # The filelike should be in binary mode, so we should decode the bytes, assuming the content is in `utf-8`
+        content = content.decode('utf-8')
+
         try:
             for line in content.split('\n'):
                 datablock, formula = re.split(r'\s+', line.strip(), 1)

--- a/aiida_codtools/parsers/cif_cod_numbers.py
+++ b/aiida_codtools/parsers/cif_cod_numbers.py
@@ -29,6 +29,9 @@ class CifCodNumbersParser(CifBaseParser):
         if not content:
             return self.exit_codes.ERROR_EMPTY_OUTPUT_FILE
 
+        # The filelike should be in binary mode, so we should decode the bytes, assuming the content is in `utf-8`
+        content = content.decode('utf-8')
+
         try:
             for line in content.split('\n'):
                 formula, identifier, count, _ = re.split(r'\s+', line.strip())

--- a/aiida_codtools/parsers/cif_split_primitive.py
+++ b/aiida_codtools/parsers/cif_split_primitive.py
@@ -30,12 +30,15 @@ class CifSplitPrimitiveParser(CifBaseParser):
         if not content:
             return self.exit_codes.ERROR_EMPTY_OUTPUT_FILE
 
+        # The filelike should be in binary mode, so we should decode the bytes, assuming the content is in `utf-8`
+        content = content.decode('utf-8')
+
         try:
             cifs = {}
             for line in content.split('\n'):
                 filename = line.strip()
                 output_name = os.path.splitext(os.path.basename(filename))[0]
-                with self.retrieved.open(filename) as handle:
+                with self.retrieved.open(filename, 'rb') as handle:
                     cifs[output_name] = CifData(file=handle)
 
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
The `put_object_from_filelike` underneath the hood will expect a binary
filehandle as it should not try to interpret the content by decoding it
but it should simply copy the bytes as is.