### PR TITLE
Bring all CLI scripts under single command `aiida-codtools`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,34 +25,39 @@ or when installing from source:
 In order to use `aiida-codtools`, after installing the package, `aiida-core` needs to be setup and configured.
 For instructions please follow the documentation of [`aiida-core`](https://aiida-core.readthedocs.io/en/latest/).
 
-After you have installed `aiida-core` and configured a computer and a code, you can easily launch a `cod-tools` calculation through AiiDA.
-The package provides a command line script `launch_calculation_cod_tools` that makes it very easy.
+The package provides a command line script `aiida-codtools` that comes with some useful commands, such as launching calculation or imports CIF files.
 Call the command with the `--help` flag to display its usage:
 
-  $ launch_calculation_cod_tools --help
+    Usage: aiida-codtools [OPTIONS] COMMAND [ARGS]...
 
-  Usage: launch_calculation_cod_tools [OPTIONS]
+      CLI for the `aiida-codtools` plugin.
 
-    Run any cod-tools calculation for the given ``CifData`` node.
+    Options:
+      -p, --profile PROFILE  Execute the command for this profile instead of the default profile.
+      -h, --help             Show this message and exit.
 
-    The ``-p/--parameters`` option takes a single string with any command line
-    parameters that you want to be passed to the calculation, and by extension
-    the cod-tools script. Example::
+    Commands:
+      calculation  Commands to launch and interact with calculations.
+      data         Commands to import, create and inspect data nodes.
+      workflow     Commands to launch and interact with workflows.
 
-        launch_calculation_cod_tools -X cif-filter -N 95 -p '--use-c-parser
-        --authors "Jane Doe; John Doe"'
+Each sub command can have multiple other sub commands.
+To enable tab completion, add the following line to your shell activation script:
 
-    The parameters will be parsed into a dictionary and passed as the
-    ``parameters`` input node to the calculation.
+    eval "$(_AIIDA_CODTOOLS_COMPLETE=source aiida-codtools)"
 
-  Options:
-    -X, --code CODE        Code that references a supported cod-tools script.
-                           [required]
-    -N, --node DATA        CifData node to use as input.  [required]
-    -p, --parameters TEXT  Command line parameters
-    -d, --daemon           Submit the process to the daemon instead of running
-                           it locally.  [default: False]
-    --help                 Show this message and exit.
+To import 10 random CIF files from the COD database, for example, you can do the following:
+
+    verdi group create cod_cif_raw
+    aiida-codtools data cif import -d cod -G cod_cif_raw -M 10
+
+After you have configured a computer and a code, you can also easily launch a `cod-tools` calculation through AiiDA:
+
+    aiida-codtools calculation launch cod-tools -X cif-filter -N 10
+
+Here `cif-filter` is the label of the code that you have configured and `10` is the pk of a `CifData` node.
+These will most likely be different for your database, so change them accordingly.
+
 
 ## Documentation
 The documentation for this package can be found on [readthedocs](http://aiida-codtools.readthedocs.io/en/latest/).

--- a/aiida_codtools/calculations/cif_base.py
+++ b/aiida_codtools/calculations/cif_base.py
@@ -75,7 +75,7 @@ class CifBaseCalculation(CalcJob):
         :param folder: an aiida.common.folders.Folder to temporarily write files on disk
         :returns: CalcInfo instance
         """
-        from aiida_codtools.common.cli import CliParameters
+        from aiida_codtools.cli.utils.parameters import CliParameters
 
         try:
             parameters = self.inputs.parameters.get_dict()

--- a/aiida_codtools/calculations/cif_cod_deposit.py
+++ b/aiida_codtools/calculations/cif_cod_deposit.py
@@ -48,7 +48,7 @@ class CifCodDepositCalculation(CifBaseCalculation):
         :param folder: an aiida.common.folders.Folder to temporarily write files on disk
         :returns: CalcInfo instance
         """
-        from aiida_codtools.common.cli import CliParameters
+        from aiida_codtools.cli.utils.parameters import CliParameters
 
         try:
             parameters = self.inputs.parameters.get_dict()

--- a/aiida_codtools/cli/__init__.py
+++ b/aiida_codtools/cli/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=wrong-import-position,wildcard-import
+"""Module for the command line interface."""
+from __future__ import absolute_import
+
+import click
+import click_completion
+
+from aiida.cmdline.params import options, types
+
+# Activate the completion of parameter types provided by the click_completion package
+click_completion.init()
+
+
+@click.group('aiida-codtools', context_settings={'help_option_names': ['-h', '--help']})
+@options.PROFILE(type=types.ProfileParamType(load_profile=True))
+def cmd_root(profile):  # pylint: disable=unused-argument
+    """CLI for the `aiida-codtools` plugin."""
+
+
+from .calculations import cmd_calculation
+from .data import cmd_cif
+from .workflows import cmd_workflow

--- a/aiida_codtools/cli/calculations/__init__.py
+++ b/aiida_codtools/cli/calculations/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=cyclic-import,reimported,unused-import,wrong-import-position
+"""Module with CLI commands for the various calculation job implementations."""
+from .. import cmd_root
+
+
+@cmd_root.group('calculation')
+def cmd_calculation():
+    """Commands to launch and interact with calculations."""
+
+
+@cmd_calculation.group('launch')
+def cmd_launch():
+    """Launch calculations."""
+
+
+# Import the sub commands to register them with the CLI
+from .cod_tools import launch_calculation

--- a/aiida_codtools/cli/calculations/cod_tools.py
+++ b/aiida_codtools/cli/calculations/cod_tools.py
@@ -8,43 +8,49 @@ import click
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils import decorators
 
+from ..utils import launch, validate
+from . import cmd_launch
 
-@click.command()
+
+@cmd_launch.command('cod-tools')
 @options.CODE(required=True, help='Code that references a supported cod-tools script.')
 @click.option(
     '-N', '--node', 'cif', type=types.DataParamType(sub_classes=('aiida.data:cif',)), required=True,
     help='CifData node to use as input.')
-@click.option('-p', '--parameters', type=click.STRING, help='Command line parameters')
+@click.option('-p', '--parameters', type=click.STRING, help='Command line parameters.')
 @click.option(
-    '-d', '--daemon', is_flag=True, default=False, show_default=True,
+    '-d', '--daemon', is_flag=True, default=False, show_default=True, callback=validate.validate_daemon_dry_run,
     help='Submit the process to the daemon instead of running it locally.')
+@options.DRY_RUN(callback=validate.validate_daemon_dry_run)
 @decorators.with_dbenv()
-def cli(code, cif, parameters, daemon):
+def launch_calculation(code, cif, parameters, daemon, dry_run):
     """Run any cod-tools calculation for the given ``CifData`` node.
 
     The ``-p/--parameters`` option takes a single string with any command line parameters that you want to be passed
     to the calculation, and by extension the cod-tools script. Example::
 
-        launch_calculation_cod_tools -X cif-filter -N 95 -p '--use-c-parser --authors "Jane Doe; John Doe"'
+        aiida-codtools calculation launch cod-tools -X cif-filter -N 95 -p '--use-c-parser --authors "Jane Doe"'
 
     The parameters will be parsed into a dictionary and passed as the ``parameters`` input node to the calculation.
     """
     from aiida import orm
     from aiida.plugins import factories
-    from aiida_codtools.common.cli import CliParameters, CliRunner
+    from aiida_codtools.cli.utils.parameters import CliParameters
     from aiida_codtools.common.resources import get_default_options
 
-    process = factories.CalculationFactory(code.get_attribute('input_plugin'))
     parameters = CliParameters.from_string(parameters).get_dictionary()
 
     inputs = {
         'cif': cif,
         'code': code,
-        'metadata': {'options': get_default_options()}
+        'metadata': {
+            'options': get_default_options(),
+            'dry_run': dry_run,
+            'store_provenance': not dry_run
+        }
     }
 
     if parameters:
         inputs['parameters'] = orm.Dict(dict=parameters)
 
-    cli_runner = CliRunner(process, inputs)
-    cli_runner.run(daemon=daemon)
+    launch.launch_process(factories.CalculationFactory(code.get_attribute('input_plugin')), daemon, **inputs)

--- a/aiida_codtools/cli/data/__init__.py
+++ b/aiida_codtools/cli/data/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=cyclic-import,unused-import,wrong-import-position
+"""Module with CLI commands for various data types."""
+from .. import cmd_root
+
+
+@cmd_root.group('data')
+def cmd_data():
+    """Commands to import, create and inspect data nodes."""
+
+
+# Import the sub commands to register them with the CLI
+from .cif import cmd_cif

--- a/aiida_codtools/cli/data/cif.py
+++ b/aiida_codtools/cli/data/cif.py
@@ -1,14 +1,22 @@
 # -*- coding: utf-8 -*-
+# yapf:disable
 """Command line interface script to import CIF files from external databases into `CifData` nodes."""
-# yapf: disable
 from __future__ import absolute_import
+
 import click
 
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators, echo
 
+from . import cmd_data
 
-@click.command()
+
+@cmd_data.group('cif')
+def cmd_cif():
+    """Commands to import, create and inspect `CifData` nodes."""
+
+
+@cmd_cif.command('import')
 @options.GROUP(help='Group in which to store the raw imported CifData nodes.', required=False)
 @click.option(
     '-d', '--database', type=click.Choice(['cod', 'icsd', 'mpds']), default='cod', show_default=True,
@@ -70,7 +78,7 @@ def launch_cif_import(group, database, max_entries, number_species, skip_partial
 
     from aiida import orm
     from aiida.plugins import factories
-    from aiida_codtools.common.cli import echo_utc
+    from aiida_codtools.cli.utils.display import echo_utc
 
     if not count_entries and group is None:
         raise click.BadParameter('you have to specify a group unless the option --count-entries is specified')

--- a/aiida_codtools/cli/utils/display.py
+++ b/aiida_codtools/cli/utils/display.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Module with display utitlies for the CLI."""
+from __future__ import absolute_import
+
+import os
+
+import click
+
+
+def echo_utc(string):
+    """Echo the string to standard out, prefixed with the current date and time in UTC format.
+
+    :param string: string to echo
+    """
+    from datetime import datetime
+    click.echo('{} | {}'.format(datetime.utcnow().isoformat(), string))
+
+
+def echo_process_results(node):
+    """Display a formatted table of the outputs registered for the given process node.
+
+    :param node: the `ProcessNode` of a terminated process
+    """
+    from aiida.common.links import LinkType
+
+    class_name = node.process_class.__name__
+    outputs = node.get_outgoing(link_type=(LinkType.CREATE, LinkType.RETURN)).all()
+
+    if hasattr(node, 'dry_run_info'):
+        click.echo('-> Files created in folder `{}`'.format(os.path.relpath(node.dry_run_info['folder'])))
+        click.echo('-> Submission script filename `{}`'.format(node.dry_run_info['script_filename']))
+        return
+
+    if node.is_finished and node.exit_message:
+        state = '{} [{}] `{}`'.format(node.process_state.value, node.exit_status, node.exit_message)
+    elif node.is_finished:
+        state = '{} [{}]'.format(node.process_state.value, node.exit_status)
+    else:
+        state = node.process_state.value
+
+    click.echo('{}<{}> terminated with state: {}'.format(class_name, node.pk, state))
+
+    if not outputs:
+        click.echo('{}<{}> registered no outputs'.format(class_name, node.pk))
+        return
+
+    click.echo('\n{link:25s} {node}'.format(link='Output link', node='Node pk and type'))
+    click.echo('{s}'.format(s='-' * 60))
+
+    for triple in sorted(outputs, key=lambda triple: triple.link_label):
+        click.echo('{:25s} {}<{}> '.format(triple.link_label, triple.node.__class__.__name__, triple.node.pk))

--- a/aiida_codtools/cli/utils/launch.py
+++ b/aiida_codtools/cli/utils/launch.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Module with launch utitlies for the CLI."""
+from __future__ import absolute_import
+
+import click
+
+from .display import echo_process_results
+
+
+def launch_process(process, daemon, **inputs):
+    """Launch a process with the given inputs.
+
+    If not sent to the daemon, the results will be displayed after the calculation finishes.
+
+    :param process: the process class
+    :param daemon: boolean, if True will submit to the daemon instead of running in current interpreter
+    :param inputs: inputs for the process
+    """
+    from aiida.engine import launch, Process, ProcessBuilder
+
+    if isinstance(process, ProcessBuilder):
+        process_name = process.process_class.__name__
+    elif issubclass(process, Process):
+        process_name = process.__name__
+    else:
+        raise TypeError('invalid type for process: {}'.format(process))
+
+    if daemon:
+        node = launch.submit(process, **inputs)
+        click.echo('Submitted {}<{}> to the daemon'.format(process_name, node.pk))
+    else:
+        if inputs.get('metadata', {}).get('dry_run', False):
+            click.echo('Running a dry run for {}...'.format(process_name))
+        else:
+            click.echo('Running a {}...'.format(process_name))
+        _, node = launch.run_get_node(process, **inputs)
+        echo_process_results(node)

--- a/aiida_codtools/cli/utils/parameters.py
+++ b/aiida_codtools/cli/utils/parameters.py
@@ -1,4 +1,4 @@
-"""Utilities for CLI scripts."""
+"""Module with CLI utilities to translate command line parameters strings to dictionaries and vice versa."""
 from __future__ import absolute_import
 
 import collections
@@ -6,20 +6,6 @@ import itertools
 import shlex
 import six
 from six.moves import zip
-
-import click
-import tabulate
-
-from aiida.cmdline.utils import echo
-
-
-def echo_utc(string):
-    """Echo the string to standard out, prefixed with the current date and time in UTC format.
-
-    :param string: string to echo
-    """
-    from datetime import datetime
-    click.echo('{} | {}'.format(datetime.utcnow().isoformat(), string))
 
 
 class CliParameters(object):  # pylint: disable=useless-object-inheritance
@@ -146,55 +132,3 @@ class CliParameters(object):  # pylint: disable=useless-object-inheritance
         :return: dictionary of command line parameters
         """
         return self._parameters
-
-
-class CliRunner(object):  # pylint: disable=useless-object-inheritance
-    """Utility class to run a process with given inputs within a CLI script."""
-
-    def __init__(self, process, inputs):
-        self._process = process
-        self._inputs = inputs
-
-    @property
-    def process(self):
-        return self._process
-
-    @property
-    def process_name(self):
-        return self._process.__name__
-
-    @property
-    def inputs(self):
-        return self._inputs
-
-    def run(self, daemon=False):
-        """Launch the process with the given inputs, by default running in the current interpreter.
-
-        :param daemon: boolean, if True, will submit the process instead of running it.
-        """
-        from aiida.engine import launch
-
-        # If daemon is True, submit the process and return
-        if daemon:
-            node = launch.submit(self.process, **self.inputs)
-            echo.echo_info('Submitted {}<{}>'.format(self.process_name, node.pk))
-            return
-
-        # Otherwise we run locally and wait for the process to finish
-        echo.echo_info('Running {}'.format(self.process_name))
-        try:
-            _, node = launch.run_get_node(self.process, **self.inputs)
-        except Exception as exception:  # pylint: disable=broad-except
-            echo.echo_critical('an exception occurred during execution: {}'.format(str(exception)))
-
-        if node.is_killed:
-            echo.echo_critical('{}<{}> was killed'.format(self.process_name, node.pk))
-        elif not node.is_finished_ok:
-            arguments = [self.process_name, node.pk, node.exit_status, node.exit_message]
-            echo.echo_warning('{}<{}> failed with exit status {}: {}'.format(*arguments))
-        else:
-            output = []
-            echo.echo_success('{}<{}> finished successfully\n'.format(self.process_name, node.pk))
-            for triple in sorted(node.get_outgoing().all(), key=lambda triple: triple.link_label):
-                output.append([triple.link_label, '{}<{}>'.format(triple.node.__class__.__name__, triple.node.pk)])
-            echo.echo(tabulate.tabulate(output, headers=['Output label', 'Node']))

--- a/aiida_codtools/cli/utils/validate.py
+++ b/aiida_codtools/cli/utils/validate.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Module with validation utitlies for the CLI."""
+from __future__ import absolute_import
+import click
+
+
+def validate_daemon_dry_run(ctx, param, value):
+    """Ensure that not both the `daemon` and `dry_run` are specified.
+
+    This should be used as the `callback` argument of both options, if they are to be mutually exclusive. Since the
+    order of calling this callback will depend on in what order they are specified by the user on the command line.
+
+    :raises: `click.BadOptionUsage` if both the `daemon` and `dry_run` options are specified.
+    :return: the value
+    """
+    if value and (ctx.params.get('daemon', False) or ctx.params.get('dry_run', False)):
+        raise click.BadOptionUsage(param.name, 'cannot use the `--daemon` and `--dry-run` flags at the same time')
+
+    return value

--- a/aiida_codtools/cli/workflows/__init__.py
+++ b/aiida_codtools/cli/workflows/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=cyclic-import,reimported,unused-import,wrong-import-position
+"""Module with CLI commands for the various work chain implementations."""
+from .. import cmd_root
+
+
+@cmd_root.group('workflow')
+def cmd_workflow():
+    """Commands to launch and interact with workflows."""
+
+
+@cmd_workflow.group('launch')
+def cmd_launch():
+    """Launch workflows."""
+
+
+# Import the sub commands to register them with the CLI
+from .cif_clean import launch_cif_clean

--- a/aiida_codtools/cli/workflows/cif_clean.py
+++ b/aiida_codtools/cli/workflows/cif_clean.py
@@ -7,8 +7,10 @@ import click
 from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
 
+from . import cmd_launch
 
-@click.command()
+
+@cmd_launch.command('cif-clean')
 @click.option(
     '-F', '--cif-filter', required=True, type=types.CodeParamType(entry_point='codtools.cif_filter'),
     help='Code that references the codtools cif_filter script.')
@@ -59,7 +61,7 @@ def launch_cif_clean(cif_filter, cif_select, group_cif_raw, group_cif_clean, gro
     from aiida import orm
     from aiida.engine import launch
     from aiida.plugins import DataFactory, WorkflowFactory
-    from aiida_codtools.common.cli import echo_utc
+    from aiida_codtools.cli.utils.display import echo_utc
     from aiida_codtools.common.resources import get_default_options
     from aiida_codtools.common.utils import get_input_node
 

--- a/aiida_codtools/common/resources.py
+++ b/aiida_codtools/common/resources.py
@@ -3,9 +3,9 @@
 
 
 def get_default_options(num_machines=1, max_wallclock_seconds=1800, withmpi=False):
-    """
-    Return an instance of the options dictionary with the minimally required parameters
-    for a JobCalculation and set to default values unless overriden
+    """Return an instance of the options dictionary with the minimally required parameters for a CalcJob.
+
+    Default values are set unless overridden through the arguments.
 
     :param num_machines: set the number of nodes, default=1
     :param max_wallclock_seconds: set the maximum number of wallclock seconds, default=1800

--- a/setup.json
+++ b/setup.json
@@ -31,9 +31,7 @@
             "codtools.cif_clean = aiida_codtools.workflows.cif_clean:CifCleanWorkChain"
         ],
         "console_scripts": [
-            "launch_calculation_cod_tools = aiida_codtools.cli.calculations.cod_tools:cli",
-            "launch_misc_cif_import = aiida_codtools.cli.misc.cif_import:launch_cif_import",
-            "launch_workflow_cif_clean = aiida_codtools.cli.workflows.cif_clean:launch_cif_clean"
+            "aiida-codtools = aiida_codtools.cli:cmd_root"
         ]
     },
     "extras_require": {
@@ -55,6 +53,8 @@
     },
     "install_requires": [
         "aiida-core>=1.0.0b6",
+        "click>=7.0",
+        "click-completion>=0.5.1",
         "matplotlib<3.0.0; python_version<'3'",
         "PyCifRW==4.2.1; python_version<'3'",
         "PyCifRW==4.4; python_version>='3'",

--- a/tests/common/test_cli.py
+++ b/tests/common/test_cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for the CLI utilities."""
 from __future__ import absolute_import
-from aiida_codtools.common.cli import CliParameters
+from aiida_codtools.cli.utils.parameters import CliParameters
 
 
 class TestCliParameters(object):  # pylint: disable=useless-object-inheritance


### PR DESCRIPTION
Fixes #70 

This prevents polluting the namespace of the user too much with lots of
executables, one for each script. Using `click` we create a single
command `aiida-codtools` that uses sub commands. Tab completion is also
provided and can be enabled by adding single line to shell activation
script.