### PR TITLE
Add `fastentrypoints` module to `setup.py`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include setup.json
 include LICENSE
 include README.md
+include utils/fastentrypoints.py
 recursive-include tests *
 recursive-include docs *

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """Setup for the `aiida-codtools` plugin which provides an interface for cod-tools scripts to `aiida-core`."""
 from __future__ import absolute_import
+from utils import fastentrypoints  # pylint: disable=unused-import
 
 
 def setup_package():

--- a/utils/fastentrypoints.py
+++ b/utils/fastentrypoints.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# Copyright (c) 2016, Aaron Christianson
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
+Monkey patch setuptools to write faster console_scripts with this format:
+
+    import sys
+    from mymodule import entry_function
+    sys.exit(entry_function())
+
+This is better.
+
+(c) 2016, Aaron Christianson
+http://github.com/ninjaaron/fast-entry_points
+'''
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+import re
+from setuptools.command import easy_install
+
+TEMPLATE = r'''
+import re
+import sys
+
+from {0} import {1}
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit({2}())'''
+
+
+@classmethod
+def get_args(cls, dist, header=None):
+    """
+    Yield write_script() argument tuples for a distribution's
+    console_scripts and gui_scripts entry points.
+    """
+    # pylint: disable=no-member,protected-access
+    if header is None:
+        header = cls.get_header()
+
+    for type_ in 'console', 'gui':
+        group = type_ + '_scripts'
+        for name, epoint in dist.get_entry_map(group).items():
+            # ensure_safe_name
+            if re.search(r'[\\/]', name):
+                raise ValueError('Path separators not allowed in script names')
+            script_text = TEMPLATE.format(epoint.module_name, epoint.attrs[0], '.'.join(epoint.attrs))
+            args = cls._get_script_args(type_, name, header, script_text)
+            for res in args:
+                yield res
+
+
+easy_install.ScriptWriter.get_args = get_args
+
+
+def main():  # pylint: disable=missing-docstring
+    import os
+    import shutil
+    import sys
+    dests = sys.argv[1:] or ['.']
+    filename = re.sub(r'\.pyc$', '.py', __file__)
+
+    for dst in dests:
+        shutil.copy(filename, dst)
+        manifest_path = os.path.join(dst, 'MANIFEST.in')
+        setup_path = os.path.join(dst, 'setup.py')
+
+        # Insert the include statement to MANIFEST.in if not present
+        with open(manifest_path, 'a+') as manifest:
+            manifest.seek(0)
+            manifest_content = manifest.read()
+            if not 'include fastentrypoints.py' in manifest_content:
+                manifest.write(('\n' if manifest_content else '') + 'include fastentrypoints.py')
+
+        # Insert the import statement to setup.py if not present
+        with open(setup_path, 'a+') as setup:
+            setup.seek(0)
+            setup_content = setup.read()
+            if not 'import fastentrypoints' in setup_content:
+                setup.seek(0)
+                setup.truncate()
+                setup.write('import fastentrypoints\n' + setup_content)


### PR DESCRIPTION
Fixes #73 

This will speed up the loading of entry points and will reduce the
loading time of the `aiida-codtools` CLI tool to ~0.2 seconds from
almost a full second.