### PR TITLE
Use `aiida-core[atomic_tools]` extra for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     postgresql: "9.6"
 
 before_install:
-    - pip install -U pip==18.1 wheel setuptools reentry
+    - pip install -U pip==18.1 wheel setuptools reentry numpy==1.16.4
 
 install:
     - pip install .[dev,docs] --no-cache-dir

--- a/setup.json
+++ b/setup.json
@@ -52,13 +52,10 @@
         ]
     },
     "install_requires": [
-        "aiida-core>=1.0.0b6",
+        "aiida-core[atomic_tools]>=1.0.0b6",
         "click>=7.0",
         "click-completion>=0.5.1",
-        "matplotlib<3.0.0; python_version<'3'",
-        "PyCifRW==4.2.1; python_version<'3'",
-        "PyCifRW==4.4; python_version>='3'",
-        "seekpath==1.8.4"
+        "matplotlib<3.0.0; python_version<'3'"
     ],
     "license": "MIT License",
     "name": "aiida_codtools",


### PR DESCRIPTION
Pinning sub dependencies like `seekpath` in our own requirements risk
creating conflicts with the requirements of `aiida-core` if they are
updated.