### PR TITLE
Fix `cif.has_partial_occupancies` in `aiida-codtools data cif import`

### DIFF
--- a/aiida_codtools/cli/data/cif.py
+++ b/aiida_codtools/cli/data/cif.py
@@ -188,7 +188,7 @@ def launch_cif_import(group, database, max_entries, number_species, skip_partial
                 name = exception.__class__.__name__
                 echo_utc('Cif<{}> skipping: encountered an error retrieving cif data: {}'.format(source_id, name))
         else:
-            if skip_partial_occupancies and cif.has_partial_occupancies():
+            if skip_partial_occupancies and cif.has_partial_occupancies:
                 if verbose:
                     echo_utc('Cif<{}> skipping: contains partial occupancies'.format(source_id))
             else:

--- a/tests/cli/data/test_cif.py
+++ b/tests/cli/data/test_cif.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument,too-many-arguments
+"""Tests for the `aiida-codtools data cif` CLI command."""
+from __future__ import absolute_import
+
+from uuid import uuid4 as UUID
+
+from aiida import orm
+from aiida_codtools.cli.data.cif import launch_cif_import
+
+
+def test_cif_import(fixture_database, run_cli_command):
+    """Test the `aiida-codtools data cif import` CLI command."""
+    max_entries = 10
+
+    # Default call
+    group = orm.Group(UUID()).store()
+    run_cli_command(launch_cif_import, ['-G', group.pk, '-M', max_entries])
+    assert group.count() == max_entries
+
+    # Dry run
+    group = orm.Group(UUID()).store()
+    run_cli_command(launch_cif_import, ['-G', group.pk, '-M', max_entries, '--dry-run'])
+    assert group.count() == 0
+
+    # Skip partial occupations
+    group = orm.Group(UUID()).store()
+    run_cli_command(launch_cif_import, ['-G', group.pk, '-M', max_entries, '--skip-partial-occupancies'])
+    assert group.count() == max_entries

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,27 @@ def fixture_database(fixture_environment):
     fixture_environment.reset_db()
 
 
+@pytest.fixture(scope='function')
+def run_cli_command():
+    """Run a `click` command with the given options.
+
+    The call will raise if the command triggered an exception or the exit code returned is non-zero
+    """
+
+    def _run_cli_command(command, options):
+        """Run the command and check the result."""
+        import traceback
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(command, options)
+
+        assert result.exception is None, ''.join(traceback.format_exception(*result.exc_info))
+        assert result.exit_code == 0, result.output
+
+    return _run_cli_command
+
+
 @pytest.fixture
 def generate_code_localhost():
     """Return a `Code` instance configured to run calculations of given entry point on localhost `Computer`."""


### PR DESCRIPTION
Fixes #78 

The `has_partial_occupancies` method was changed to a property but it
was still being called in the CLI, causing an exception.