### PR TITLE
Homogenize the exit codes of all `CalcJob` implementations

### DIFF
--- a/aiida_codtools/calculations/cif_base.py
+++ b/aiida_codtools/calculations/cif_base.py
@@ -38,21 +38,19 @@ class CifBaseCalculation(CalcJob):
         spec.output('messages', valid_type=Dict, required=False,
             help='Warning and error messages returned by script.')
 
-        spec.exit_code(100, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(110, 'ERROR_NO_OUTPUT_FILES',
+        spec.exit_code(300, 'ERROR_NO_OUTPUT_FILES',
             message='Neither the output for the error file could be read from the retrieved folder.')
-        spec.exit_code(111, 'ERROR_READING_OUTPUT_FILE',
+        spec.exit_code(311, 'ERROR_READING_OUTPUT_FILE',
             message='The output file could not be read from the retrieved folder.')
-        spec.exit_code(112, 'ERROR_READING_ERROR_FILE',
+        spec.exit_code(312, 'ERROR_READING_ERROR_FILE',
             message='The error file could not be read from the retrieved folder.')
-        spec.exit_code(113, 'ERROR_EMPTY_OUTPUT_FILE',
+        spec.exit_code(313, 'ERROR_EMPTY_OUTPUT_FILE',
             message='The output file is empty.')
-        spec.exit_code(120, 'ERROR_INVALID_COMMAND_LINE_OPTION',
+        spec.exit_code(320, 'ERROR_INVALID_COMMAND_LINE_OPTION',
             message='Invalid command line option passed.')
-        spec.exit_code(130, 'ERROR_PARSING_OUTPUT_DATA',
+        spec.exit_code(400, 'ERROR_PARSING_OUTPUT_DATA',
             message='The output file could not be parsed.')
-        spec.exit_code(131, 'ERROR_PARSING_CIF_DATA',
+        spec.exit_code(410, 'ERROR_PARSING_CIF_DATA',
             message='The output file could not be parsed into a CifData object.')
 
     def _validate_resources(self):

--- a/aiida_codtools/calculations/cif_cod_deposit.py
+++ b/aiida_codtools/calculations/cif_cod_deposit.py
@@ -29,13 +29,13 @@ class CifCodDepositCalculation(CifBaseCalculation):
     def define(cls, spec):
         # yapf: disable
         super(CifCodDepositCalculation, cls).define(spec)
-        spec.exit_code(400, 'ERROR_DEPOSITION_UNKNOWN',
+        spec.exit_code(300, 'ERROR_DEPOSITION_UNKNOWN',
             message='The deposition failed for unknown reasons.')
-        spec.exit_code(410, 'ERROR_DEPOSITION_INVALID_INPUT',
+        spec.exit_code(310, 'ERROR_DEPOSITION_INVALID_INPUT',
             message='The deposition failed because the input was invalid.')
-        spec.exit_code(420, 'ERROR_DEPOSITION_DUPLICATE',
+        spec.exit_code(410, 'ERROR_DEPOSITION_DUPLICATE',
             message='The deposition failed because one or more CIFs already exist in the COD.')
-        spec.exit_code(430, 'ERROR_DEPOSITION_UNCHANGED',
+        spec.exit_code(420, 'ERROR_DEPOSITION_UNCHANGED',
             message='The structure is unchanged and so deposition is unnecessary.')
 
     def prepare_for_submission(self, folder):

--- a/aiida_codtools/parsers/cif_base.py
+++ b/aiida_codtools/parsers/cif_base.py
@@ -30,11 +30,7 @@ class CifBaseParser(Parser):
 
     def parse(self, **kwargs):
         """Parse the contents of the output files retrieved in the `FolderData`."""
-        try:
-            output_folder = self.retrieved
-        except exceptions.NotExistent:
-            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
-
+        output_folder = self.retrieved
         filename_stdout = self.node.get_attribute('output_filename')
         filename_stderr = self.node.get_attribute('error_filename')
 


### PR DESCRIPTION
Fixes #85 

The range `100-199` has been reserved for scheduler errors reported by
the engine of `aiida-core` itself. The current standard is that the
range `300-399` represents critical errors whereas `400-*` are used for
errors that can potentially be recovered from.