### PR TITLE
Drop python 2 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,12 +32,3 @@
     language: system
     files: '^(setup.json)'
     pass_filenames: false
-
-- repo: https://github.com/python-modernize/python-modernize.git
-  rev: a234ce4e185cf77a55632888f1811d83b4ad9ef2
-  hooks:
-  - id: python-modernize
-    exclude: ^docs/
-    args:
-      - --write
-      - --nobackups

--- a/.pylintrc
+++ b/.pylintrc
@@ -279,7 +279,7 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,future.builtins
+redefining-builtins-modules=
 
 
 [MISCELLANEOUS]

--- a/aiida_codtools/calculations/cif_base.py
+++ b/aiida_codtools/calculations/cif_base.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Generic `CalcJob` implementation that can easily be extended to work with any of the `cod-tools` scripts."""
-from __future__ import absolute_import
 import copy
-import six
 
 from aiida.common import datastructures, exceptions
 from aiida.engine import CalcJob
@@ -18,14 +16,14 @@ class CifBaseCalculation(CalcJob):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifBaseCalculation, cls).define(spec)
-        spec.input('metadata.options.input_filename', valid_type=six.string_types, default='aiida.in',
+        super().define(spec)
+        spec.input('metadata.options.input_filename', valid_type=str, default='aiida.in',
             help='Filename to which the input for the code that is to be run will be written.')
-        spec.input('metadata.options.output_filename', valid_type=six.string_types, default='aiida.out',
+        spec.input('metadata.options.output_filename', valid_type=str, default='aiida.out',
             help='Filename to which the content of stdout of the code that is to be run will be written.')
-        spec.input('metadata.options.error_filename', valid_type=six.string_types, default='aiida.err',
+        spec.input('metadata.options.error_filename', valid_type=str, default='aiida.err',
             help='Filename to which the content of stderr of the code that is to be run will be written.')
-        spec.input('metadata.options.parser_name', valid_type=six.string_types, default=cls._default_parser,
+        spec.input('metadata.options.parser_name', valid_type=str, default=cls._default_parser,
             help='Define the parser to be used by setting its entry point name.')
         spec.input('metadata.options.attach_messages', valid_type=bool, default=False,
             help='When True, warnings and errors written to stderr will be attached as the `messages` output node')

--- a/aiida_codtools/calculations/cif_cell_contents.py
+++ b/aiida_codtools/calculations/cif_cell_contents.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """CalcJob plugin for the `cif_cell_contents` script of the `cod-tools` package."""
-from __future__ import absolute_import
 
 from aiida.orm import Dict
 from aiida_codtools.calculations.cif_base import CifBaseCalculation
@@ -15,5 +14,5 @@ class CifCellContentsCalculation(CifBaseCalculation):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifCellContentsCalculation, cls).define(spec)
+        super().define(spec)
         spec.output('formulae', valid_type=Dict, help='A dictionary of formulae present in the CIF.')

--- a/aiida_codtools/calculations/cif_cod_check.py
+++ b/aiida_codtools/calculations/cif_cod_check.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """CalcJob plugin for the `cif_cod_check` script of the `cod-tools` package."""
-from __future__ import absolute_import
 
 from aiida.orm import Dict
 from aiida_codtools.calculations.cif_base import CifBaseCalculation
@@ -14,6 +13,6 @@ class CifCodCheckCalculation(CifBaseCalculation):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifCodCheckCalculation, cls).define(spec)
+        super().define(spec)
         spec.input('metadata.options.attach_messages', valid_type=bool, default=True)
         spec.output('messages', valid_type=Dict, help='Warning and error messages returned by the script.')

--- a/aiida_codtools/calculations/cif_cod_deposit.py
+++ b/aiida_codtools/calculations/cif_cod_deposit.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """CalcJob plugin for the `cif_cod_deposit` script of the `cod-tools` package."""
-from __future__ import absolute_import
 
 import copy
 
@@ -28,7 +27,7 @@ class CifCodDepositCalculation(CifBaseCalculation):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifCodDepositCalculation, cls).define(spec)
+        super().define(spec)
         spec.exit_code(300, 'ERROR_DEPOSITION_UNKNOWN',
             message='The deposition failed for unknown reasons.')
         spec.exit_code(310, 'ERROR_DEPOSITION_INVALID_INPUT',
@@ -57,13 +56,13 @@ class CifCodDepositCalculation(CifBaseCalculation):
 
         # The input file should simply contain the relative filename that contains the CIF to be deposited
         with folder.open(self.options.input_filename, 'w') as handle:
-            handle.write(u'{}\n'.format(self.filename_cif))
+            handle.write('{}\n'.format(self.filename_cif))
 
         # Write parameters that relate to the config file to that file and remove them from the CLI parameters
         with folder.open(self.filename_config, 'w') as handle:
             for key in self._config_keys:
                 if key in parameters:
-                    handle.write(u'{}={}\n'.format(key, parameters.pop(key)))
+                    handle.write('{}={}\n'.format(key, parameters.pop(key)))
 
         cli_parameters = copy.deepcopy(self._default_cli_parameters)
         cli_parameters.update(parameters)

--- a/aiida_codtools/calculations/cif_cod_numbers.py
+++ b/aiida_codtools/calculations/cif_cod_numbers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """CalcJob plugin for the `cif_cod_numbers` script of the `cod-tools` package."""
-from __future__ import absolute_import
 
 from aiida.orm import Dict
 from aiida_codtools.calculations.cif_base import CifBaseCalculation
@@ -14,5 +13,5 @@ class CifCodNumbersCalculation(CifBaseCalculation):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifCodNumbersCalculation, cls).define(spec)
+        super().define(spec)
         spec.output('numbers', valid_type=Dict, help='Mapping of COD IDs found with their formula and count.')

--- a/aiida_codtools/calculations/cif_filter.py
+++ b/aiida_codtools/calculations/cif_filter.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """CalcJob plugin for the `cif_filter` script of the `cod-tools` package."""
-from __future__ import absolute_import
 
 from aiida.orm import CifData
 from aiida_codtools.calculations.cif_base import CifBaseCalculation
@@ -12,5 +11,5 @@ class CifFilterCalculation(CifBaseCalculation):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifFilterCalculation, cls).define(spec)
+        super().define(spec)
         spec.output('cif', valid_type=CifData, help='The CIF produced by the script.')

--- a/aiida_codtools/calculations/cif_select.py
+++ b/aiida_codtools/calculations/cif_select.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """CalcJob plugin for the `cif_select` script of the `cod-tools` package."""
-from __future__ import absolute_import
 
 from aiida.orm import CifData
 from aiida_codtools.calculations.cif_base import CifBaseCalculation
@@ -12,5 +11,5 @@ class CifSelectCalculation(CifBaseCalculation):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifSelectCalculation, cls).define(spec)
+        super().define(spec)
         spec.output('cif', valid_type=CifData, help='The CIF produced by the script.')

--- a/aiida_codtools/calculations/cif_split_primitive.py
+++ b/aiida_codtools/calculations/cif_split_primitive.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """CalcJob plugin for the `cif_split_primitive` script of the `cod-tools` package."""
-from __future__ import absolute_import
 
 import os
 from aiida.orm import CifData
@@ -16,11 +15,11 @@ class CifSplitPrimitiveCalculation(CifBaseCalculation):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifSplitPrimitiveCalculation, cls).define(spec)
+        super().define(spec)
         spec.output_namespace('cifs', valid_type=CifData, help='The CIFs produced by the script.', dynamic=True)
 
     def prepare_for_submission(self, folder):
-        calcinfo = super(CifSplitPrimitiveCalculation, self).prepare_for_submission(folder)
+        calcinfo = super().prepare_for_submission(folder)
 
         split_dir = folder.get_abs_path(self._directory_split)
         os.mkdir(split_dir)

--- a/aiida_codtools/calculations/functions/primitive_structure_from_cif.py
+++ b/aiida_codtools/calculations/functions/primitive_structure_from_cif.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Calculation function to generate a primitive structure from a `CifData` using Seekpath."""
-from __future__ import absolute_import
 from seekpath.hpkot import SymmetryDetectionError
 
 from aiida.common import exceptions

--- a/aiida_codtools/cli/__init__.py
+++ b/aiida_codtools/cli/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=wrong-import-position,wildcard-import
 """Module for the command line interface."""
-from __future__ import absolute_import
 
 import click
 import click_completion

--- a/aiida_codtools/cli/calculations/cod_tools.py
+++ b/aiida_codtools/cli/calculations/cod_tools.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Command line interface script to launch almost any cod-tools calculation through AiiDA."""
 # yapf: disable
-from __future__ import absolute_import
 
 import click
 

--- a/aiida_codtools/cli/data/cif.py
+++ b/aiida_codtools/cli/data/cif.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # yapf:disable
 """Command line interface script to import CIF files from external databases into `CifData` nodes."""
-from __future__ import absolute_import
 
 import click
 
@@ -74,7 +73,7 @@ def launch_cif_import(group, database, max_entries, number_species, skip_partial
     import inspect
     from CifFile.StarFile import StarError
     from datetime import datetime
-    from six.moves.urllib.error import HTTPError
+    from urllib.error import HTTPError
 
     from aiida import orm
     from aiida.plugins import factories

--- a/aiida_codtools/cli/utils/display.py
+++ b/aiida_codtools/cli/utils/display.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Module with display utitlies for the CLI."""
-from __future__ import absolute_import
 
 import os
 

--- a/aiida_codtools/cli/utils/launch.py
+++ b/aiida_codtools/cli/utils/launch.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Module with launch utitlies for the CLI."""
-from __future__ import absolute_import
 
 import click
 

--- a/aiida_codtools/cli/utils/parameters.py
+++ b/aiida_codtools/cli/utils/parameters.py
@@ -1,14 +1,11 @@
 """Module with CLI utilities to translate command line parameters strings to dictionaries and vice versa."""
-from __future__ import absolute_import
 
 import collections
 import itertools
 import shlex
-import six
-from six.moves import zip
 
 
-class CliParameters(object):  # pylint: disable=useless-object-inheritance
+class CliParameters:
     """Object to represent command line parameters that are passed to a cod-tools script.
 
     It can be constructed from a dictionary or single string representation and provides methods to return those
@@ -47,7 +44,7 @@ class CliParameters(object):  # pylint: disable=useless-object-inheritance
         if string is None:
             string = ''
 
-        if not isinstance(string, six.string_types):
+        if not isinstance(string, str):
             raise TypeError('string has to be a string type, got: {}'.format(type(string)))
 
         dictionary = {}

--- a/aiida_codtools/cli/utils/validate.py
+++ b/aiida_codtools/cli/utils/validate.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Module with validation utitlies for the CLI."""
-from __future__ import absolute_import
 import click
 
 

--- a/aiida_codtools/cli/workflows/cif_clean.py
+++ b/aiida_codtools/cli/workflows/cif_clean.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Command line interface script to launch `CifCleanWorkChain` per node or in bulk."""
 # yapf: disable
-from __future__ import absolute_import
 import click
 
 from aiida.cmdline.params import types

--- a/aiida_codtools/common/utils.py
+++ b/aiida_codtools/common/utils.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Common utilities."""
 
-from __future__ import absolute_import
-
 
 def get_input_node(cls, value):
     """Return a `Node` of a given class and given value.

--- a/aiida_codtools/parsers/cif_base.py
+++ b/aiida_codtools/parsers/cif_base.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Generic `Parser` implementation that can easily be extended to work with any of the `cod-tools` scripts."""
-from __future__ import absolute_import
 import traceback
 
 from aiida.common import exceptions
@@ -20,7 +19,7 @@ class CifBaseParser(Parser):
     _supported_calculation_class = CifBaseCalculation
 
     def __init__(self, node):
-        super(CifBaseParser, self).__init__(node)
+        super().__init__(node)
         if not issubclass(node.process_class, self._supported_calculation_class):
             raise exceptions.ParsingError(
                 'Node process class must be a {} but node<{}> has process class {}'.format(

--- a/aiida_codtools/parsers/cif_cell_contents.py
+++ b/aiida_codtools/parsers/cif_cell_contents.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Parser implementation for the `CifCellContentsCalculation` plugin."""
-from __future__ import absolute_import
 import re
 import traceback
 

--- a/aiida_codtools/parsers/cif_cod_check.py
+++ b/aiida_codtools/parsers/cif_cod_check.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Parser implementation for the `CifCodCheckCalculation` plugin."""
-from __future__ import absolute_import
 
 from aiida_codtools.calculations.cif_cod_check import CifCodCheckCalculation
 from aiida_codtools.parsers.cif_base import CifBaseParser

--- a/aiida_codtools/parsers/cif_cod_deposit.py
+++ b/aiida_codtools/parsers/cif_cod_deposit.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Generic `Parser` implementation that can easily be extended to work with any of the `cod-tools` scripts."""
-from __future__ import absolute_import
 
 import re
 

--- a/aiida_codtools/parsers/cif_cod_numbers.py
+++ b/aiida_codtools/parsers/cif_cod_numbers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Parser implementation for the `CifCodNumbersCalculation` plugin."""
-from __future__ import absolute_import
 import re
 import traceback
 

--- a/aiida_codtools/parsers/cif_split_primitive.py
+++ b/aiida_codtools/parsers/cif_split_primitive.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Parser implementation for the `CifSplitPrimitiveCalculation` plugin."""
-from __future__ import absolute_import
 import os
 import traceback
 

--- a/aiida_codtools/workflows/cif_clean.py
+++ b/aiida_codtools/workflows/cif_clean.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """WorkChain to clean a `CifData` using `cif_filter` and `cif_select` from cod-tools and parse a `StructureData`."""
 # pylint: disable=inconsistent-return-statements,no-member
-from __future__ import absolute_import
 
 from aiida import orm
 from aiida.common import exceptions
@@ -24,7 +23,7 @@ class CifCleanWorkChain(WorkChain):
     @classmethod
     def define(cls, spec):
         # yapf: disable
-        super(CifCleanWorkChain, cls).define(spec)
+        super().define(spec)
         spec.expose_inputs(CifFilterCalculation, namespace='cif_filter', exclude=('cif',))
         spec.expose_inputs(CifSelectCalculation, namespace='cif_select', exclude=('cif',))
         spec.input('cif', valid_type=orm.CifData,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,13 +56,13 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'aiida-codtools'
+project = 'aiida-codtools'
 copyright_first_year = 2014
 copyright_owners = 'ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE (Theory and Simulation of Materials (THEOS) and National Centre for Computational Design and Discovery of Novel Materials (NCCR MARVEL)), Switzerland'
 
 current_year = time.localtime().tm_year
 copyright_year_string = current_year if current_year == copyright_first_year else '{}-{}'.format(copyright_first_year, current_year)
-copyright = u'{}, {}. All rights reserved'.format(copyright_year_string, copyright_owners)
+copyright = '{}, {}. All rights reserved'.format(copyright_year_string, copyright_owners)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/user_guide/cif_base.rst
+++ b/docs/source/user_guide/cif_base.rst
@@ -78,7 +78,7 @@ Outputs
 
     would print::
 
-        {u'output_messages': [u'cif_cod_check: test.cif data_4000000: _publ_section_title is undefined']}
+        {'output_messages': ['cif_cod_check: test.cif data_4000000: _publ_section_title is undefined']}
 
 Errors
 ------

--- a/docs/source/user_guide/cif_cell_contents.rst
+++ b/docs/source/user_guide/cif_cell_contents.rst
@@ -28,11 +28,11 @@ Outputs
 
     would print::
 
-        {u'formulae': {
-            u'4000001': u'C24 H17 F5 Fe',
-            u'4000002': u'C24 H17 F5 Fe',
-            u'4000003': u'C24 H17 F5 Fe',
-            u'4000004': u'C22 H8 F10 Fe'
+        {'formulae': {
+            '4000001': 'C24 H17 F5 Fe',
+            '4000002': 'C24 H17 F5 Fe',
+            '4000003': 'C24 H17 F5 Fe',
+            '4000004': 'C22 H8 F10 Fe'
                       }})
 
     .. note:: ``data_`` is not prepended to the CIF datablock name -- the

--- a/setup.json
+++ b/setup.json
@@ -8,7 +8,6 @@
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7"
@@ -43,14 +42,12 @@
     },
     "extras_require": {
         "dev": [
-            "pgtest>=1.1.3",
-            "pre-commit>=1.17.0",
-            "prospector==1.1.7",
-            "pylint==1.9.4; python_version<'3.0'",
-            "pylint==2.3.1; python_version>='3.0'",
-            "pytest==4.3.0",
-            "pytest-regressions==1.0.5",
-            "yapf==0.28.0"
+            "pgtest~=1.1",
+            "pre-commit~=1.20",
+            "prospector~=1.1",
+            "pytest~=4.3",
+            "pytest-regressions~=1.0",
+            "yapf~=0.28.0"
         ],
         "docs": [
             "Sphinx",
@@ -59,12 +56,13 @@
         ]
     },
     "install_requires": [
-        "aiida-core[atomic_tools]>=1.0.0,<2.0.0",
-        "click>=7.0",
-        "click-completion>=0.5.1"
+        "aiida-core[atomic_tools]~=1.0",
+        "click~=7.0",
+        "click-completion~=0.5.1"
     ],
     "license": "MIT License",
     "name": "aiida_codtools",
+    "python_requires": ">=3.5",
     "url": "https://github.com/aiidateam/aiida-codtools",
     "version": "2.0.0"
 }

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 """Setup for the `aiida-codtools` plugin which provides an interface for cod-tools scripts to `aiida-core`."""
-from __future__ import absolute_import
 from utils import fastentrypoints  # pylint: disable=unused-import
 
 

--- a/tests/calculations/test_cif_cod_deposit.py
+++ b/tests/calculations/test_cif_cod_deposit.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument,too-many-arguments
 """Tests for the `CifCodDepositCalculation` class."""
-from __future__ import absolute_import
 
 from aiida import orm
 from aiida.common import datastructures

--- a/tests/cli/data/test_cif.py
+++ b/tests/cli/data/test_cif.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument,too-many-arguments
 """Tests for the `aiida-codtools data cif` CLI command."""
-from __future__ import absolute_import
 
 from uuid import uuid4 as UUID
 

--- a/tests/common/test_cli.py
+++ b/tests/common/test_cli.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """Tests for the CLI utilities."""
-from __future__ import absolute_import
 from aiida_codtools.cli.utils.parameters import CliParameters
 
 
-class TestCliParameters(object):  # pylint: disable=useless-object-inheritance
+class TestCliParameters:
     """Tests for the `CliParameters` object."""
 
     test_parameters_string = "--print-datablocks --authors 'John Doe; Jane Doe;' --year 2001"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # pylint: disable=redefined-outer-name
 """Initialise a text database and profile for pytest."""
-from __future__ import absolute_import
 
 import io
 import os

--- a/tests/parsers/test_cif_filter.py
+++ b/tests/parsers/test_cif_filter.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 """Tests for the `CifBaseParser`."""
-from __future__ import absolute_import
 from aiida_codtools.calculations.cif_filter import CifFilterCalculation
 
 

--- a/utils/fastentrypoints.py
+++ b/utils/fastentrypoints.py
@@ -32,7 +32,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-'''
+"""
 Monkey patch setuptools to write faster console_scripts with this format:
 
     import sys
@@ -43,10 +43,7 @@ This is better.
 
 (c) 2016, Aaron Christianson
 http://github.com/ninjaaron/fast-entry_points
-'''
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
+"""
 import re
 from setuptools.command import easy_install
 

--- a/utils/validate_version_number.py
+++ b/utils/validate_version_number.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Pre-commit script to ensure that version numbers in `setup.json` and `aiida_codtools/__init__.py` match."""
-from __future__ import absolute_import
 import os
 import json
 import sys


### PR DESCRIPTION
Fixes #94 

Drop python 2 support

The following commands were executed to clean all source files:

    sed -i '/from __future__.*$/d' {} +
    sed -i 's/(object):/:/g' {} +
    sed -i 's/super([^)]*,[^)]*)/super()/g' {} +
    sed -i '/\(import six\|from six\).*$/d' {} +
    sed -i '/\(six\.add_metaclass\).*$/d' {} +
    sed -i 's/six.integer_types/int/g' {} +
    sed -i 's/six.string_types/str/g' {} +
    sed -i 's/six.text_type/str/g' {} +
    sed -i 's/six.binary_type/bytes/g' {} +
    sed -i 's/six.moves.StringIO/io.StringIO/g' {} +
    sed -i 's/six.StringIO/io.StringIO/g' {} +
    sed -i 's/six.moves.BytesIO/io.BytesIO/g' {} +
    sed -i 's/six.BytesIO/io.BytesIO/g' {} +
    sed -i 's/six.moves.range/range/g' {} +
    sed -i 's|six.iterkeys(\([^)]*\))|\1.keys()|' {} +
    sed -i 's|six.iteritems(\([^)]*\))|\1.items()|' {} +
    sed -i 's|six.itervalues(\([^)]*\))|\1.values()|' {} +

The operations were automatically on all files using `find -exec`:

    find . -type f -not -path './.git*'

Note the exclusion of the `.git` folder which is very important.