### PR TITLE
`CifCleanWorkChain`: use lambdas for ports with node defaults

### DIFF
--- a/aiida_codtools/workflows/cif_clean.py
+++ b/aiida_codtools/workflows/cif_clean.py
@@ -28,11 +28,11 @@ class CifCleanWorkChain(WorkChain):
         spec.expose_inputs(CifSelectCalculation, namespace='cif_select', exclude=('cif',))
         spec.input('cif', valid_type=orm.CifData,
             help='The CifData node that is to be cleaned.')
-        spec.input('parse_engine', valid_type=orm.Str, default=orm.Str('pymatgen'),
+        spec.input('parse_engine', valid_type=orm.Str, default=lambda: orm.Str('pymatgen'),
             help='The atomic structure engine to parse the cif and create the structure.')
-        spec.input('symprec', valid_type=orm.Float, default=orm.Float(5E-3),
+        spec.input('symprec', valid_type=orm.Float, default=lambda: orm.Float(5E-3),
             help='The symmetry precision used by SeeKpath for crystal symmetry refinement.')
-        spec.input('site_tolerance', valid_type=orm.Float, default=orm.Float(5E-4),
+        spec.input('site_tolerance', valid_type=orm.Float, default=lambda: orm.Float(5E-4),
             help='The fractional coordinate distance tolerance for finding overlapping sites (pymatgen only).')
         spec.input('group_cif', valid_type=orm.Group, required=False, non_db=True,
             help='An optional Group to which the final cleaned CifData node will be added.')


### PR DESCRIPTION
Fixes #99 

This has been supported since `aiida-core==1.0.0` and is the safer
approach and will avoid annoying warning messages.