### PR TITLE
Dependencies: update requirement to `aiida-core~=2.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,6 @@ jobs:
             run: pip install -e .[dev]
 
         -   name: Run pytest
+            env:
+                AIIDA_WARN_v3: True
             run: pytest -sv tests

--- a/aiida_codtools/cli/calculations/cod_tools.py
+++ b/aiida_codtools/cli/calculations/cod_tools.py
@@ -52,4 +52,4 @@ def launch_calculation(code, cif, parameters, daemon, dry_run):
     if parameters:
         inputs['parameters'] = orm.Dict(dict=parameters)
 
-    launch.launch_process(factories.CalculationFactory(code.get_attribute('input_plugin')), daemon, **inputs)
+    launch.launch_process(factories.CalculationFactory(code.base.attributes.get('input_plugin')), daemon, **inputs)

--- a/aiida_codtools/cli/data/cif.py
+++ b/aiida_codtools/cli/data/cif.py
@@ -121,7 +121,7 @@ def launch_cif_import(
     if importer_api_key is not None:
         importer_parameters['api_key'] = importer_api_key
 
-    importer_class = factories.DbImporterFactory(database)
+    importer_class = factories.DbImporterFactory(f'core.{database}')
     importer = importer_class(**importer_parameters)
 
     if database == 'mpds':

--- a/aiida_codtools/parsers/cif_base.py
+++ b/aiida_codtools/parsers/cif_base.py
@@ -29,11 +29,11 @@ class CifBaseParser(Parser):
     def parse(self, **kwargs):
         """Parse the contents of the output files retrieved in the `FolderData`."""
         output_folder = self.retrieved
-        filename_stdout = self.node.get_attribute('output_filename')
-        filename_stderr = self.node.get_attribute('error_filename')
+        filename_stdout = self.node.base.attributes.get('output_filename')
+        filename_stderr = self.node.base.attributes.get('error_filename')
 
         try:
-            with output_folder.open(filename_stderr, 'r') as handle:
+            with output_folder.base.repository.open(filename_stderr, 'r') as handle:
                 exit_code = self.parse_stderr(handle)
         except (OSError, IOError):
             self.logger.exception('Failed to read the stderr file\n%s', traceback.format_exc())
@@ -43,7 +43,7 @@ class CifBaseParser(Parser):
             return exit_code
 
         try:
-            with output_folder.open(filename_stdout, 'rb') as handle:
+            with output_folder.base.repository.open(filename_stdout, 'rb') as handle:
                 handle.seek(0)
                 exit_code = self.parse_stdout(handle)
         except (OSError, IOError):

--- a/aiida_codtools/parsers/cif_split_primitive.py
+++ b/aiida_codtools/parsers/cif_split_primitive.py
@@ -37,7 +37,7 @@ class CifSplitPrimitiveParser(CifBaseParser):
             for line in content.split('\n'):
                 filename = line.strip()
                 output_name = os.path.splitext(os.path.basename(filename))[0]
-                with self.retrieved.open(filename, 'rb') as handle:
+                with self.retrieved.base.repository.open(filename, 'rb') as handle:
                     cifs[output_name] = CifData(file=handle)
 
         except Exception:  # pylint: disable=broad-except

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core[atomic_tools]~=2.0.0b1',
+    'aiida-core[atomic_tools]~=2.0',
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,14 +108,14 @@ def fixture_calc_job_node():
         entry_point = format_entry_point_string('aiida.calculations', entry_point_name)
 
         node = CalcJobNode(computer=computer, process_type=entry_point)
-        node.set_attribute('input_filename', 'aiida.in')
-        node.set_attribute('output_filename', 'aiida.out')
-        node.set_attribute('error_filename', 'aiida.err')
+        node.base.attributes.set('input_filename', 'aiida.in')
+        node.base.attributes.set('output_filename', 'aiida.out')
+        node.base.attributes.set('error_filename', 'aiida.err')
         node.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
         node.set_option('max_wallclock_seconds', 1800)
 
         if attributes:
-            node.set_attribute_many(attributes)
+            node.base.attributes.set_many(attributes)
 
         node.store()
 
@@ -123,8 +123,8 @@ def fixture_calc_job_node():
         filepath = os.path.join(basepath, 'parsers', 'fixtures', entry_point_name[len('codtools.'):], test_name)
 
         retrieved = FolderData()
-        retrieved.put_object_from_tree(filepath)
-        retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
+        retrieved.base.repository.put_object_from_tree(filepath)
+        retrieved.base.links.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
         retrieved.store()
 
         return node


### PR DESCRIPTION
Also enable the `AIIDA_WARN_v3` environment variable in the CI workflow
to have deprecation warnings show up and address them.