### PR TITLE
Improved cif parsing checks

### DIFF
--- a/src/aiida_codtools/calculations/functions/check_formula.py
+++ b/src/aiida_codtools/calculations/functions/check_formula.py
@@ -116,7 +116,7 @@ def _check_formula(cif, structure):
 
     report += f'cif [{formula_c}]  structure [{formula_s}]'
 
-    has_partial_occupancies = structure.get_extra('partial_occupancies')
+    has_partial_occupancies = not structure.get_pymatgen().is_ordered
     if has_partial_occupancies:
         report += ' | Partial occupancies'
 

--- a/src/aiida_codtools/calculations/functions/check_formula.py
+++ b/src/aiida_codtools/calculations/functions/check_formula.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""Work function to check the composition of a `StructureData` against the chemical formula of a CifData node."""
+
+import re
+
+from CifFile import StarError
+from aiida.engine import workfunction
+from aiida.plugins import WorkflowFactory
+import numpy as np
+
+
+def get_formula_from_cif(cif):
+    """
+    Semplification of aiida.orm.cif.get_formulae
+    Works for MPDS cif files as well.
+    """
+    formula_tags = ('_chemical_formula_sum', '_pauling_file_chemical_formula')
+    datablock = cif.values[cif.values.keys()[0]]
+    formula = None
+    for formula_tag in formula_tags:
+        if formula_tag in datablock.keys():
+            formula = datablock[formula_tag]
+            break
+    return formula
+
+
+# this function will be added to aiida.orm.nodes.data.cif
+def parse_formula(formula):
+    """
+    Parses the Hill formulae. Does not need spaces as separators.
+    Works also for partial occupancies and for chemical groups enclosed in round/square/curly brackets.
+    Elements are counted and a dictionary is returned.
+    e.g.  'C[NH2]3NO3'  -->  {'C': 1, 'N': 4, 'H': 6, 'O': 3}
+    """
+
+    def chemcount_str_to_number(string):
+        if not string:
+            quantity = 1
+        else:
+            quantity = float(string)
+            if quantity.is_integer():
+                quantity = int(quantity)
+        return quantity
+
+    contents = {}
+
+    # split blocks with parentheses
+    for block in re.split(r'(\([^\)]*\)[^A-Z\(\[\{]*|\[[^\]]*\][^A-Z\(\[\{]*|\{[^\}]*\}[^A-Z\(\[\{]*)', formula):
+        if not block:  # block is void
+            continue
+
+        # get molecular formula (within parentheses) & count
+        group = re.search(r'[\{\[\(](.+)[\}\]\)]([\.\d]*)', block)
+        if group is None:  # block does not contain parentheses
+            molformula = block
+            molcount = 1
+        else:
+            molformula = group.group(1)
+            molcount = chemcount_str_to_number(group.group(2))
+
+        for part in re.findall(r'[A-Z][^A-Z\s]*', molformula.replace(' ', '')):  # split at uppercase letters
+            match = re.match(r'(\D+)([\.\d]+)?', part)  # separates element and count
+
+            if match is None:
+                continue
+
+            species = match.group(1)
+            quantity = chemcount_str_to_number(match.group(2)) * molcount
+            contents[species] = contents.get(species, 0) + quantity
+    return contents
+
+
+def parse_formula_from_structure(structure):
+    """
+    Returns a dictionary with the elements of a StructureData and their quantities.
+    """
+    formula = {}
+    for site in structure.get_pymatgen().sites:
+        for element, count in site.species.items():
+            formula[element.symbol] = formula.get(element.symbol, 0) + count
+    return formula
+
+
+class MissingElementsError(Exception):
+    """
+    An exception that will be raised if the parsed structure misses some elements or has additional elements with
+    respect to the chemical formula reported in the CIF file. This is probably due to non-defined or non-listed sites.
+    """
+
+
+class DifferentCompositionsError(Exception):
+    """
+    An exception that will be raised if the parsed structure has a different composition with respect to the chemical
+    formula reported in the CIF file.
+    """
+
+
+def _check_formula(cif, structure):
+    """
+    Compare CIF formula against StructureData formula and report any inconsistency.
+    """
+    # pylint: disable=too-many-locals
+    report = ''
+    formula_s = structure.get_formula('hill', ' ')
+    formula_c = None
+    try:
+        assert len(cif.values.keys()) == 1, 'More than one CIF key.'
+        formula_c = get_formula_from_cif(cif)
+    except StarError:  # ignore unparsable CIF files (this should not happen)
+        report += ' | Unparsable CIF'
+        formula_c = cif.get_attribute('formulae')
+
+    if not formula_c:
+        # we cannot do any check without a formula... hope for the best
+        report += ' | No formula in CIF'
+        return report
+
+    report += f'cif [{formula_c}]  structure [{formula_s}]'
+
+    has_partial_occupancies = structure.get_extra('has_partial_occupancies')
+    if has_partial_occupancies:
+        report += ' | Partial occupancies'
+
+    # get formula dictionaries {element: count}
+    formuladic_s = parse_formula_from_structure(structure)
+    formuladic_c = parse_formula(formula_c)
+    # remove elements with zero occupancy
+    for key in [key for key, value in formuladic_c.items() if value == 0.]:
+        formuladic_c.pop(key)
+
+    # FIRST CHECK: find missing elements, ignore vacancies ('X')
+    # (symmetric difference of the sets -- contains elements not present in both sets)
+    missing_elements = (set(formuladic_s.keys()) ^ set(formuladic_c.keys())) - {'X'}
+    if missing_elements:
+        report += f' | Missing elements: {list(missing_elements)}'
+        raise MissingElementsError(report)
+        #return False, report
+
+    # SECOND CHECK: find inconsistent formulas
+    # ratios of all the elements should be the same
+    elements = formuladic_c.keys()
+    elcount_c = np.array([formuladic_c[key] for key in elements])
+    elcount_s = np.array([formuladic_s[key] for key in elements])
+
+    # ratios should be (all) > 1
+    # for integer occ., for each element the absolute tolerance on the ratio is 0.5 / (the smallest count)
+    # if the ratio difference is larger than this value, the structure can have more than one atom difference
+    if any(elcount_c > elcount_s):
+        ratios = elcount_c / elcount_s
+        atol = 0.499999 / np.ceil(elcount_s)
+    else:
+        ratios = elcount_s / elcount_c
+        atol = 0.499999 / np.ceil(elcount_c)
+
+    if has_partial_occupancies:
+        # for partial occ., compare ratios against the first one
+        # use an absolute tolerance of 0.05 + a 2 % relative tolerance
+        compare_with_ratio = ratios[0]
+        atol = 0.05
+        rtol = 0.02
+    else:
+        # for integer occ., compare ratios against the first one rounded to the nearest integer
+        # use only the absolute tolerance estimated above
+        compare_with_ratio = np.round(ratios[0])
+        rtol = 0.
+
+    bad_ratios = not np.allclose(ratios, compare_with_ratio, atol=atol, rtol=rtol)
+    if bad_ratios:
+        report += f' | Different compositions (ratios: {list(zip(elements, [round(r, 3) for r in ratios]))})'
+        raise DifferentCompositionsError(report)
+    report += ' | OK'
+
+    return report
+
+
+@workfunction
+def check_formula(cif, structure):
+    """
+    Compare CIF formula against StructureData formula and report any inconsistency.
+    """
+    CifCleanWorkChain = WorkflowFactory('codtools.cif_clean')  # pylint: disable=invalid-name
+
+    report_msg = None
+
+    # check structure chemical formula against cif one
+    try:
+        report_msg = _check_formula(cif, structure)
+    except MissingElementsError as err:
+        report_msg, = err.args
+        return CifCleanWorkChain.exit_codes.ERROR_FORMULA_MISSING_ELEMENTS
+    except DifferentCompositionsError as err:
+        report_msg, = err.args
+        return CifCleanWorkChain.exit_codes.ERROR_FORMULA_DIFFERENT_COMPOSITION
+    finally:
+        if report_msg:
+            structure.set_extra('check_formula_log', report_msg)
+
+    return structure

--- a/src/aiida_codtools/calculations/functions/primitive_structure_from_cif.py
+++ b/src/aiida_codtools/calculations/functions/primitive_structure_from_cif.py
@@ -8,13 +8,6 @@ from aiida.tools.data.cif import InvalidOccupationsError
 from seekpath.hpkot import SymmetryDetectionError
 
 
-def has_partial_occupancies(structure):
-    """
-    Detect if a structure has partial occupancies (vacancies/substitutions).
-    """
-    return not structure.get_pymatgen().is_ordered
-
-
 @calcfunction
 def primitive_structure_from_cif(cif, parse_engine, symprec, site_tolerance, occupancy_tolerance):
     # pylint: disable=too-many-return-statements
@@ -65,7 +58,6 @@ def primitive_structure_from_cif(cif, parse_engine, symprec, site_tolerance, occ
         'formula_hill': structure.get_formula(mode='hill'),
         'formula_hill_compact': structure.get_formula(mode='hill_compact'),
         'chemical_system': f"-{'-'.join(sorted(structure.get_symbols_set()))}-",
-        'has_partial_occupancies': has_partial_occupancies(structure),
     }
 
     for key in ['spacegroup_international', 'spacegroup_number', 'bravais_lattice', 'bravais_lattice_extended']:

--- a/src/aiida_codtools/calculations/functions/primitive_structure_from_cif.py
+++ b/src/aiida_codtools/calculations/functions/primitive_structure_from_cif.py
@@ -8,8 +8,16 @@ from aiida.tools.data.cif import InvalidOccupationsError
 from seekpath.hpkot import SymmetryDetectionError
 
 
+def has_partial_occupancies(structure):
+    """
+    Detect if a structure has partial occupancies (vacancies/substitutions).
+    """
+    return not structure.get_pymatgen().is_ordered
+
+
 @calcfunction
-def primitive_structure_from_cif(cif, parse_engine, symprec, site_tolerance):
+def primitive_structure_from_cif(cif, parse_engine, symprec, site_tolerance, occupancy_tolerance):
+    # pylint: disable=too-many-return-statements
     """Attempt to parse the given `CifData` and create a `StructureData` from it.
 
     First the raw CIF file is parsed with the given `parse_engine`. The resulting `StructureData` is then passed through
@@ -21,12 +29,19 @@ def primitive_structure_from_cif(cif, parse_engine, symprec, site_tolerance):
     :param symprec: a `Float` node with symmetry precision for determining primitive cell in SeeKpath
     :param site_tolerance: a `Float` node with the fractional coordinate distance tolerance for finding overlapping
         sites. This will only be used if the parse_engine is pymatgen
+    :param occupancy_tolerance: a `Float` node with the occupancy tolerance below which occupancies will be scaled down
+        to 1. This will only be used if the parse_engine is pymatgen
     :return: the primitive `StructureData` as determined by SeeKpath
     """
     CifCleanWorkChain = WorkflowFactory('codtools.cif_clean')  # pylint: disable=invalid-name
 
     try:
-        structure = cif.get_structure(converter=parse_engine.value, site_tolerance=site_tolerance.value, store=False)
+        structure = cif.get_structure(
+            converter=parse_engine.value,
+            site_tolerance=site_tolerance.value,
+            occupancy_tolerance=occupancy_tolerance.value,
+            store=False
+        )
     except exceptions.UnsupportedSpeciesError:
         return CifCleanWorkChain.exit_codes.ERROR_CIF_HAS_UNKNOWN_SPECIES
     except InvalidOccupationsError:
@@ -50,6 +65,7 @@ def primitive_structure_from_cif(cif, parse_engine, symprec, site_tolerance):
         'formula_hill': structure.get_formula(mode='hill'),
         'formula_hill_compact': structure.get_formula(mode='hill_compact'),
         'chemical_system': f"-{'-'.join(sorted(structure.get_symbols_set()))}-",
+        'has_partial_occupancies': has_partial_occupancies(structure),
     }
 
     for key in ['spacegroup_international', 'spacegroup_number', 'bravais_lattice', 'bravais_lattice_extended']:

--- a/src/aiida_codtools/cli/data/cif.py
+++ b/src/aiida_codtools/cli/data/cif.py
@@ -155,7 +155,7 @@ def launch_cif_import(
             # actually apply the filtering in the import here.
             query_parameters['query']['classes'] = 'multinary'
 
-        if element is not None:
+        if element:
             query_parameters['query']['elements'] = '-'.join(element)
 
     else:
@@ -163,7 +163,7 @@ def launch_cif_import(
         if number_species is not None:
             query_parameters['number_of_elements'] = number_species
 
-        if element is not None:
+        if element:
             query_parameters['element'] = ' '.join(element)
 
     # Collect the dictionary of not None parameters passed to the launch script and print to screen

--- a/src/aiida_codtools/cli/data/cif.py
+++ b/src/aiida_codtools/cli/data/cif.py
@@ -40,6 +40,14 @@ def cmd_cif():
     help='Import only cif files with this number of different species.'
 )
 @click.option(
+    '-e',
+    '--element',
+    type=click.STRING,
+    required=False,
+    multiple=True,
+    help='Elements that must be included (multiple).'
+)
+@click.option(
     '-o', '--skip-partial-occupancies', is_flag=True, default=False, help='Skip entries that have partial occupancies.'
 )
 @click.option(
@@ -75,7 +83,7 @@ def cmd_cif():
 @click.option('-n', '--dry-run', is_flag=True, default=False, help='Perform a dry-run.')
 @decorators.with_dbenv()
 def launch_cif_import(
-    group, database, max_entries, number_species, skip_partial_occupancies, importer_server, importer_db_host,
+    group, database, max_entries, number_species, element, skip_partial_occupancies, importer_server, importer_db_host,
     importer_db_name, importer_db_password, importer_api_url, importer_api_key, count_entries, batch_count, dry_run
 ):
     """Import cif files from various structural databases, store them as CifData nodes and add them to a Group.
@@ -147,10 +155,16 @@ def launch_cif_import(
             # actually apply the filtering in the import here.
             query_parameters['query']['classes'] = 'multinary'
 
+        if element is not None:
+            query_parameters['query']['elements'] = '-'.join(element)
+
     else:
 
         if number_species is not None:
             query_parameters['number_of_elements'] = number_species
+
+        if element is not None:
+            query_parameters['element'] = ' '.join(element)
 
     # Collect the dictionary of not None parameters passed to the launch script and print to screen
     local_vars = locals()

--- a/src/aiida_codtools/cli/workflows/cif_clean.py
+++ b/src/aiida_codtools/cli/workflows/cif_clean.py
@@ -40,11 +40,23 @@ from . import cmd_launch
     '-p', '--parse-engine', type=click.Choice(['ase', 'pymatgen']), default='pymatgen', show_default=True,
     help='Select the parse engine for parsing the structure from the cleaned cif if requested.')
 @click.option(
+    '-K', '--symprec', type=click.FLOAT, default=5e-3, show_default=True,
+    help='The symmetry precision used by SeeKpath for crystal symmetry refinement.')
+@click.option(
+    '-T', '--site-tolerance', type=click.FLOAT, default=5e-4, show_default=True,
+    help='The fractional coordinate distance tolerance for finding overlapping sites (pymatgen only).')
+@click.option(
+    '-F', '--skip-formula-check', is_flag=True, default=False,
+    help='Skip the formula check that compares the structure with the chemical formula in the cif file.')
+@click.option(
+    '-O', '--occupancy-tolerance', type=click.FLOAT, default=1.0, show_default=True,
+    help='If total occupancy of a site is between 1 and occupancy_tolerance, the occupancies will be scaled down to 1.')
+@click.option(
     '-d', '--daemon', is_flag=True, default=False, show_default=True,
     help='Submit the process to the daemon instead of running it locally.')
 @decorators.with_dbenv()
 def launch_cif_clean(cif_filter, cif_select, group_cif_raw, group_cif_clean, group_structure, group_workchain, node,
-    max_entries, skip_check, parse_engine, daemon):
+    max_entries, skip_check, parse_engine, symprec, site_tolerance, skip_formula_check, occupancy_tolerance, daemon):
     """Run the `CifCleanWorkChain` on the entries in a group with raw imported CifData nodes.
 
     It will use the `cif_filter` and `cif_select` scripts of `cod-tools` to clean the input cif file. Additionally, if
@@ -132,8 +144,10 @@ def launch_cif_clean(cif_filter, cif_select, group_cif_raw, group_cif_clean, gro
     })
 
     node_parse_engine = get_input_node(orm.Str, parse_engine)
-    node_site_tolerance = get_input_node(orm.Float, 5E-4)
-    node_symprec = get_input_node(orm.Float, 5E-3)
+    node_site_tolerance = get_input_node(orm.Float, site_tolerance)
+    node_occupancy_tolerance = get_input_node(orm.Float, occupancy_tolerance)
+    node_symprec = get_input_node(orm.Float, symprec)
+    node_skip_formula_check = get_input_node(orm.Bool, skip_formula_check)
 
     for cif in nodes:
 
@@ -155,7 +169,9 @@ def launch_cif_clean(cif_filter, cif_select, group_cif_raw, group_cif_clean, gro
             },
             'parse_engine': node_parse_engine,
             'site_tolerance': node_site_tolerance,
+            'occupancy_tolerance': node_occupancy_tolerance,
             'symprec': node_symprec,
+            'skip_formula_check': node_skip_formula_check,
         }
 
         if group_cif_clean is not None:

--- a/src/aiida_codtools/workflows/cif_clean.py
+++ b/src/aiida_codtools/workflows/cif_clean.py
@@ -34,6 +34,11 @@ class CifCleanWorkChain(WorkChain):
             help='The symmetry precision used by SeeKpath for crystal symmetry refinement.')
         spec.input('site_tolerance', valid_type=orm.Float, default=lambda: orm.Float(5E-4),
             help='The fractional coordinate distance tolerance for finding overlapping sites (pymatgen only).')
+        spec.input('occupancy_tolerance', valid_type=orm.Float, default=orm.Float(1.0),
+            help='If total occupancy of a site is between 1 and occupancy_tolerance, the occupancies will be scaled'\
+                    + 'down to 1 (pymatgen only).')
+        spec.input('skip_formula_check', valid_type=orm.Bool, default=orm.Bool(False),
+            help='Skip the formula check that compares the structure with the chemical formula in the cif file.')
         spec.input('group_cif', valid_type=orm.Group, required=False, non_db=True,
             help='An optional Group to which the final cleaned CifData node will be added.')
         spec.input('group_structure', valid_type=orm.Group, required=False, non_db=True,
@@ -46,6 +51,9 @@ class CifCleanWorkChain(WorkChain):
             cls.inspect_select_calculation,
             if_(cls.should_parse_cif_structure)(
                 cls.parse_cif_structure,
+                if_(cls.should_check_chemical_formula)(
+                    cls.check_chemical_formula,
+                ),
             ),
             cls.results,
         )
@@ -73,9 +81,15 @@ class CifCleanWorkChain(WorkChain):
             message='SeeKpath failed to determine the primitive structure.')
         spec.exit_code(421, 'ERROR_SEEKPATH_INCONSISTENT_SYMMETRY',
             message='SeeKpath detected inconsistent symmetry operations.')
+        spec.exit_code(430, 'ERROR_FORMULA_MISSING_ELEMENTS',
+            message='The structure has missing elements/sites, compared to the cif chemical formula.')
+        spec.exit_code(431, 'ERROR_FORMULA_DIFFERENT_COMPOSITION',
+            message='The structure\'s chemical composition is incompatible with the cif chemical formula.')
+        spec.exit_code(432, 'ERROR_FORMULA_CHECK_FAILED',
+            message='Failed to check chemical formulas.')
 
     def run_filter_calculation(self):
-        """Run the CifFilterCalculation on the CifData input node."""
+        """Run the `CifFilterCalculation` on the `CifData` input node."""
         inputs = self.exposed_inputs(CifFilterCalculation, namespace='cif_filter')
         inputs.metadata.call_link_label = 'cif_filter'
         inputs.cif = self.inputs.cif
@@ -86,7 +100,7 @@ class CifCleanWorkChain(WorkChain):
         return ToContext(cif_filter=calculation)
 
     def inspect_filter_calculation(self):
-        """Inspect the result of the CifFilterCalculation, verifying that it produced a CifData output node."""
+        """Inspect the result of the `CifFilterCalculation`, verifying that it produced a `CifData` output node."""
         try:
             node = self.ctx.cif_filter
             self.ctx.cif = node.outputs.cif
@@ -95,7 +109,7 @@ class CifCleanWorkChain(WorkChain):
             return self.exit_codes.ERROR_CIF_FILTER_FAILED
 
     def run_select_calculation(self):
-        """Run the CifSelectCalculation on the CifData output node of the CifFilterCalculation."""
+        """Run the `CifSelectCalculation` on the `CifData` output node of the `CifFilterCalculation`."""
         inputs = self.exposed_inputs(CifSelectCalculation, namespace='cif_select')
         inputs.metadata.call_link_label = 'cif_select'
         inputs.cif = self.ctx.cif
@@ -106,7 +120,7 @@ class CifCleanWorkChain(WorkChain):
         return ToContext(cif_select=calculation)
 
     def inspect_select_calculation(self):
-        """Inspect the result of the CifSelectCalculation, verifying that it produced a CifData output node."""
+        """Inspect the result of the `CifSelectCalculation`, verifying that it produced a `CifData` output node."""
         try:
             node = self.ctx.cif_select
             self.ctx.cif = node.outputs.cif
@@ -115,7 +129,7 @@ class CifCleanWorkChain(WorkChain):
             return self.exit_codes.ERROR_CIF_SELECT_FAILED
 
     def should_parse_cif_structure(self):
-        """Return whether the primitive structure should be created from the final cleaned CifData."""
+        """Return whether the primitive structure should be created from the final cleaned `CifData`."""
         return 'group_structure' in self.inputs
 
     def parse_cif_structure(self):
@@ -141,6 +155,7 @@ class CifCleanWorkChain(WorkChain):
             'cif': self.ctx.cif,
             'parse_engine': self.inputs.parse_engine,
             'site_tolerance': self.inputs.site_tolerance,
+            'occupancy_tolerance': self.inputs.occupancy_tolerance,
             'symprec': self.inputs.symprec,
             'metadata': {
                 'call_link_label': 'primitive_structure_from_cif'
@@ -158,15 +173,51 @@ class CifCleanWorkChain(WorkChain):
             self.ctx.exit_code = self.exit_codes(node.exit_status)  # pylint: disable=too-many-function-args
             self.report(self.ctx.exit_code.message)
         else:
+            self.ctx.primitive_structure = structure
+
+    def should_check_chemical_formula(self):
+        """
+        Return whether the composition of the structure should be checked against the chemical formula of the `CifData`.
+        """
+        return (not self.inputs.skip_formula_check) and hasattr(self.ctx, 'primitive_structure')
+
+    def check_chemical_formula(self):
+        """Check the composition of the `StructureData` against the chemical formula of the `CifData`."""
+        from aiida_codtools.calculations.functions.check_formula import check_formula
+
+        parse_inputs = {
+            'cif': self.ctx.cif,
+            'structure': self.ctx.primitive_structure,
+            'metadata': {
+                'call_link_label': 'check_formula'
+            }
+        }
+
+        try:
+            structure, node = check_formula.run_get_node(**parse_inputs)
+        except Exception:  # pylint: disable=broad-except
+            self.ctx.exit_code = self.exit_codes.ERROR_FORMULA_CHECK_FAILED
+            self.report(self.ctx.exit_code.message)
+            return
+
+        if node.is_failed:
+            self.ctx.exit_code = self.exit_codes(node.exit_status)  # pylint: disable=too-many-function-args
+            self.report(self.ctx.exit_code.message)
+        else:
             self.ctx.structure = structure
 
     def results(self):
         """If successfully created, add the cleaned `CifData` and `StructureData` as output nodes to the workchain.
 
         The filter and select calculations were successful, so we return the cleaned CifData node. If the `group_cif`
-        was defined in the inputs, the node is added to it. If the structure should have been parsed, verify that it
-        is was put in the context by the `parse_cif_structure` step and add it to the group and outputs, otherwise
+        was defined in the inputs, the node is added to it.
+        If the structure should have been parsed and the formula check was skipped, verify that `primitive_structure`
+        was put in the context by the `parse_cif_structure` step and add it to the group and outputs, otherwise
         return the finish status that should correspond to the exit code of the `primitive_structure_from_cif` function.
+        If the structure should have been parsed and the formula check was performed, verify that `structure` was put
+        in the context by the `check_chemical_formula` step and add it to the group and outputs, otherwise return the
+        finish status that should correspond to the exit code of the `primitive_structure_from_cif` or the
+        `check_formula` function.
         """
         self.out('cif', self.ctx.cif)
 
@@ -175,7 +226,10 @@ class CifCleanWorkChain(WorkChain):
 
         if 'group_structure' in self.inputs:
             try:
-                structure = self.ctx.structure
+                if self.inputs.skip_formula_check:
+                    structure = self.ctx.primitive_structure
+                else:
+                    structure = self.ctx.structure
             except AttributeError:
                 return self.ctx.exit_code
 


### PR DESCRIPTION
Fixes #98

From @lorisercole's original description in #106

---

Detects the wrong parsing of certain CIF files with missing sites (fixes #98).

### Chemical formula checks
#### check_formula work function
The new work function `check_formula` compares the formula reported in the CIF file with the composition of a `StructureData`.
It raises specific exceptions if:
- the structure has *missing/additional elements*, compared to the CIF formula
- the *composition is different* to the one reported in the CIF formula

Vacancies (element `'X'`) are ignored.

In order to compare the compositions, the ratios between the amounts of the elements are compared (for each element: `ratio = element_count_CIF_formula / element_count_StructureData_formula`). All the ratios should be the same. 
There is a *tolerance* that should account for the finite precision of the amounts reported in the chemical formula.
- For partially-occupied structures, a good threshold is an absolute tolerance of 0.05 + a 2% relative tolerance. Of course in general this threshold might be too strict or too loose. Often the chemical formulas reported are approximated.
- For structures with no partial occupancies, the threshold is the minimum ratio difference that would produce a StructureData with one atom more/less.

#### cif-clean workchain
I added a step `check_chemical_formula` to the cif-clean workchain. It is executed *after* the `parse_cif_structure` step, and can be skipped using the `skip_formula_check` input flag. If the check fails, the workchain fails, i.e. it does not return a StructureData (even though this node was generated in the previous step).

### Other additions
- `occupancy_tolerance` added to the inputs of the cif-clean workchain. It is used in the `primitive_structure_from_cif` calcfunction. I noticed that sometimes the site occupations of CIF files with partial occupancies are not super precise (few digits reported). This may cause the `cif.get_structure` method to fail because site occupations can be slightly above 1.0. A small occupancy tolerance (above 1.0) helps to avoid this issue when needed.
- `sym_prec` and `site_tolerance` were hard-coded in the `cif_clean` CLI: I added them to the inputs.
- possibility of manually selecting multiple nodes in the `cif_clean` CLI
- option to query for specific elements when importing CIF files using the `aiida-codtools` CLI.