### PR TITLE
CLI: update to be compatible with `aiida-core==2.1` (#136)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida-core[atomic_tools]~=2.0',
+    'aiida-core[atomic_tools]~=2.1',
 ]
 
 [project.urls]

--- a/src/aiida_codtools/cli/__init__.py
+++ b/src/aiida_codtools/cli/__init__.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=wrong-import-position
 """Module for the command line interface."""
+from aiida.cmdline.groups import VerdiCommandGroup
 from aiida.cmdline.params import options, types
 import click
 
 
-@click.group('aiida-codtools', context_settings={'help_option_names': ['-h', '--help']})
+@click.group('aiida-codtools', cls=VerdiCommandGroup, context_settings={'help_option_names': ['-h', '--help']})
 @options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
 def cmd_root():
     """CLI for the `aiida-codtools` plugin."""

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Tests for CLI commands."""
+from __future__ import annotations
+
+import subprocess
+
+import click
+import pytest
+
+from aiida_codtools.cli import cmd_root
+
+
+def recurse_commands(command: click.Command, parents: list[str] = None):
+    """Recursively return all subcommands that are part of ``command``.
+
+    :param command: The click command to start with.
+    :param parents: A list of strings that represent the parent commands leading up to the current command.
+    :returns: A list of strings denoting the full path to the current command.
+    """
+    if isinstance(command, click.Group):
+        for command_name in command.commands:
+            subcommand = command.get_command(None, command_name)
+            if parents is not None:
+                subparents = parents + [command.name]
+            else:
+                subparents = [command.name]
+            yield from recurse_commands(subcommand, subparents)
+
+    if parents is not None:
+        yield parents + [command.name]
+    else:
+        yield [command.name]
+
+
+@pytest.mark.parametrize('command', recurse_commands(cmd_root))
+@pytest.mark.parametrize('help_option', ('--help', '-h'))
+def test_commands_help_option(command, help_option):
+    """Test the help options for all subcommands of the CLI.
+
+    The usage of ``subprocess.run`` is on purpose because using :meth:`click.Context.invoke`, which is used by the
+    ``run_cli_command`` fixture that should usually be used in testing CLI commands, does not behave exactly the same
+    compared to a direct invocation on the command line. The invocation through ``invoke`` does not go through all the
+    parent commands and so might not get all the necessary initializations.
+    """
+    result = subprocess.run(command + [help_option], check=False, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert 'Usage:' in result.stdout


### PR DESCRIPTION
Currently the CLI is broken with `aiida-core==2.1`. The reason is that we are using the `PROFILE` option, which relies on the command that it is attached to configure certain things, such as the context. In v2.1, the behavior was changed causing the commands to except because the `PROFILE` option cannot find certain attributes it expects in the context.

For the `PROFILE` option to work, the root command should use the class `aiida.cmdline.groups.VerdiCommandGroup` as its `cls`. This class defines a custom context class that is necessary. It also automatically provides the verbosity option for all subcommands, so the explicit declaration can now be removed.

The problem was not detected in the unit tests because they only show up when the root command is invoked. The unit tests call the subcommands directly though, and this circumvents the root command. This is documented behavior of `click` and there is no way around it. The only solution is to call the commands through the command  line interface exactly as they would be called normally.

This is now done in the `test_root.py` file. The test parametrizes over all existing (sub)commands and directly calls it as a subprocess. This guarantees that the root command is called including its specific context that needs to be setup.